### PR TITLE
[設定/ライブラリ] 閲覧履歴・PDFキャッシュ削除機能を追加

### DIFF
--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -97,6 +97,12 @@ class AuthNotifier extends _$AuthNotifier {
   Future<void> deleteAccount() async {
     final authRepo = ref.read(authRepositoryProvider);
     final userRepo = ref.read(userRepositoryProvider);
+    // deleteUser()後にauthStateChangesが発火してAuthNotifierが破棄される可能性があるため、
+    // ref.readで取得するデータソースは非同期処理の前にすべて退避しておく。
+    final searchedHistoryDs = ref.read(searchedHistoryLocalDataSourceProvider);
+    final pdfDs = ref.read(pdfLocalDataSourceProvider);
+    final searchHistoryDs = ref.read(searchHistoryDataSourceProvider);
+
     final user = authRepo.currentUser;
     if (user == null || user.email == null) return;
     final email = user.email!;
@@ -113,18 +119,26 @@ class AuthNotifier extends _$AuthNotifier {
       rethrow;
     }
     // アカウント削除成功後、全ローカルデータを消去（失敗してもアカウント削除は成功とみなす）
-    await _clearAllLocalData();
+    await _clearAllLocalData(
+      searchedHistoryDs: searchedHistoryDs,
+      pdfDs: pdfDs,
+      searchHistoryDs: searchHistoryDs,
+    );
   }
 
-  Future<void> _clearAllLocalData() async {
+  Future<void> _clearAllLocalData({
+    required SearchedHistoryLocalDataSource searchedHistoryDs,
+    required PdfLocalDataSource pdfDs,
+    required SearchHistoryDataSource searchHistoryDs,
+  }) async {
     try {
-      await ref.read(searchedHistoryLocalDataSourceProvider).deleteAllHistory();
+      await searchedHistoryDs.deleteAllHistory();
     } catch (_) {}
     try {
-      await ref.read(pdfLocalDataSourceProvider).deleteAllPdf();
+      await pdfDs.deleteAllPdf();
     } catch (_) {}
     try {
-      await ref.read(searchHistoryDataSourceProvider).deleteAllHistory();
+      await searchHistoryDs.deleteAllHistory();
     } catch (_) {}
     try {
       await NotificationDbController.deleteAllNotifications();

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -3,6 +3,10 @@ import "package:kenryo_tankyu/core/constants/feature/user_value.dart";
 import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_repository_provider.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/providers/user_repository_provider.dart';
 import 'package:kenryo_tankyu/features/auth/domain/models/auth.dart';
+import 'package:kenryo_tankyu/features/notification/data/datasources/notification_db.dart';
+import 'package:kenryo_tankyu/features/search/data/datasources/search_history_data_source.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/searched_history_local_data_source.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'auth_provider.g.dart';
@@ -108,5 +112,22 @@ class AuthNotifier extends _$AuthNotifier {
       } catch (_) {}
       rethrow;
     }
+    // アカウント削除成功後、全ローカルデータを消去（失敗してもアカウント削除は成功とみなす）
+    await _clearAllLocalData();
+  }
+
+  Future<void> _clearAllLocalData() async {
+    try {
+      await ref.read(searchedHistoryLocalDataSourceProvider).deleteAllHistory();
+    } catch (_) {}
+    try {
+      await ref.read(pdfLocalDataSourceProvider).deleteAllPdf();
+    } catch (_) {}
+    try {
+      await ref.read(searchHistoryDataSourceProvider).deleteAllHistory();
+    } catch (_) {}
+    try {
+      await NotificationDbController.deleteAllNotifications();
+    } catch (_) {}
   }
 }

--- a/lib/features/auth/presentation/providers/auth_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.g.dart
@@ -73,7 +73,7 @@ final class AuthNotifierProvider extends $NotifierProvider<AuthNotifier, Auth> {
   }
 }
 
-String _$authNotifierHash() => r'642a9f0c08ccfda1953a2f3339f75d5d7505833f';
+String _$authNotifierHash() => r'cb83a0aa1197d6155fa0498f9ab84de814d8eda7';
 
 abstract class _$AuthNotifier extends $Notifier<Auth> {
   Auth build();

--- a/lib/features/notification/data/datasources/notification_db.dart
+++ b/lib/features/notification/data/datasources/notification_db.dart
@@ -139,4 +139,9 @@ class NotificationDbController {
       {'isRead': 1},
     );
   }
+
+  static Future<void> deleteAllNotifications() async {
+    final Database db = await database;
+    await db.delete('notification');
+  }
 }

--- a/lib/features/research_work/presentation/providers/searched_provider.g.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.g.dart
@@ -60,7 +60,7 @@ final class ResearchWorkProvider extends $FunctionalProvider<
   }
 }
 
-String _$researchWorkHash() => r'c79ee15529bdc74d9f43555a3544f2fe93ba4d33';
+String _$researchWorkHash() => r'ee2409657d34009b311ecdf8f987f999ddbe3738';
 
 final class ResearchWorkFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<Searched>, int> {

--- a/lib/features/search/presentation/widgets/result_preview_content.dart
+++ b/lib/features/search/presentation/widgets/result_preview_content.dart
@@ -37,11 +37,13 @@ class ResultPreviewContent extends ConsumerWidget {
                         child: const Text('キャンセル'),
                       ),
                       TextButton(
-                        onPressed: () {
-                          ref
+                        onPressed: () async {
+                          await ref
                               .read(historyControllerProvider.notifier)
                               .deleteHistory(searched.documentID);
-                          Navigator.of(context).pop();
+                          if (context.mounted) {
+                            Navigator.of(context).pop();
+                          }
                         },
                         child: const Text('消去'),
                       ),

--- a/lib/features/settings/presentation/screens/settings_page.dart
+++ b/lib/features/settings/presentation/screens/settings_page.dart
@@ -1,3 +1,5 @@
+import 'package:kenryo_tankyu/features/settings/presentation/widgets/delete_data_dialog.dart';
+import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:kenryo_tankyu/presentation/widget/error_dialog.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
 import 'package:flutter/material.dart';
@@ -152,6 +154,11 @@ class SettingsPage extends ConsumerWidget {
                   )
                 : const SizedBox(),
             ListTile(
+              title: const Text('履歴の削除'),
+              leading: const Icon(Icons.history),
+              onTap: () => _showDeleteDataDialog(context, ref),
+            ),
+            ListTile(
               title: const Text('ログアウト'),
               leading: const Icon(Icons.logout),
               onTap: () async {
@@ -237,6 +244,56 @@ class SettingsPage extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _showDeleteDataDialog(
+      BuildContext context, WidgetRef ref) async {
+    final repository = ref.read(userArchiveRepositoryProvider);
+
+    final List<DateTime> historyDates;
+    final List<({DateTime date, int bytes})> pdfEntries;
+    try {
+      historyDates = await repository.getAllHistorySavedDates();
+      pdfEntries = await repository.getAllPdfCacheEntries();
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('データの取得に失敗しました')),
+        );
+      }
+      return;
+    }
+    if (!context.mounted) return;
+
+    final result = await showDialog<String?>(
+      context: context,
+      builder: (_) => DeleteDataDialog(
+        historyDates: historyDates,
+        pdfEntries: pdfEntries,
+        onDeleteAllHistory: () async {
+          await ref.read(historyControllerProvider.notifier).deleteAllHistory();
+        },
+        onDeleteHistoryBefore: (before) async {
+          await ref
+              .read(historyControllerProvider.notifier)
+              .deleteHistoryBefore(before);
+        },
+        onDeleteAllPdf: () async {
+          await ref.read(pdfCacheControllerProvider.notifier).deleteAll();
+        },
+        onDeletePdfBefore: (before) async {
+          await ref
+              .read(pdfCacheControllerProvider.notifier)
+              .deleteBefore(before);
+        },
+      ),
+    );
+
+    if (result != null && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(result)),
+      );
+    }
   }
 
   void _showPermissionDeniedDialog(BuildContext context) {

--- a/lib/features/settings/presentation/widgets/delete_data_dialog.dart
+++ b/lib/features/settings/presentation/widgets/delete_data_dialog.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/archive_stats.dart';
+
+class DeleteDataDialog extends StatefulWidget {
+  final List<DateTime> historyDates;
+  final List<PdfCacheEntry> pdfEntries;
+  final Future<void> Function() onDeleteAllHistory;
+  final Future<void> Function(DateTime before) onDeleteHistoryBefore;
+  final Future<void> Function() onDeleteAllPdf;
+  final Future<void> Function(DateTime before) onDeletePdfBefore;
+
+  const DeleteDataDialog({
+    super.key,
+    required this.historyDates,
+    required this.pdfEntries,
+    required this.onDeleteAllHistory,
+    required this.onDeleteHistoryBefore,
+    required this.onDeleteAllPdf,
+    required this.onDeletePdfBefore,
+  });
+
+  @override
+  State<DeleteDataDialog> createState() => _DeleteDataDialogState();
+}
+
+class _DeleteDataDialogState extends State<DeleteDataDialog>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  double _nDays = 30;
+  bool _isDeleting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  DateTime get _cutoff =>
+      DateTime.now().subtract(Duration(days: _nDays.round()));
+
+  int get _affectedHistoryCount =>
+      widget.historyDates.where((d) => d.isBefore(_cutoff)).length;
+
+  int get _affectedPdfBytes => widget.pdfEntries
+      .where((e) => e.date.isBefore(_cutoff))
+      .fold(0, (sum, e) => sum + e.bytes);
+
+  int get _totalPdfBytes =>
+      widget.pdfEntries.fold(0, (sum, e) => sum + e.bytes);
+
+  Future<void> _run(Future<void> Function() action, String successMsg) async {
+    setState(() => _isDeleting = true);
+    try {
+      await action();
+      if (mounted) Navigator.pop(context, successMsg);
+    } catch (_) {
+      if (mounted) {
+        setState(() => _isDeleting = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('削除に失敗しました')),
+        );
+      }
+    }
+  }
+
+  void _onDeleteBefore() {
+    if (_tabController.index == 0) {
+      _run(
+        () => widget.onDeleteHistoryBefore(_cutoff),
+        '${_nDays.round()}日以上前の閲覧履歴を削除しました',
+      );
+    } else {
+      _run(
+        () => widget.onDeletePdfBefore(_cutoff),
+        '${_nDays.round()}日以上前のPDFキャッシュを削除しました',
+      );
+    }
+  }
+
+  void _onDeleteAll() {
+    if (_tabController.index == 0) {
+      _run(widget.onDeleteAllHistory, '全ての閲覧履歴を削除しました');
+    } else {
+      _run(widget.onDeleteAllPdf, '全てのPDFキャッシュを削除しました');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final nDaysRound = _nDays.round();
+    final isHistoryTab = _tabController.index == 0;
+
+    final canDeleteBefore =
+        isHistoryTab ? _affectedHistoryCount > 0 : _affectedPdfBytes > 0;
+
+    return AlertDialog(
+      title: const Text('履歴の削除'),
+      contentPadding: const EdgeInsets.fromLTRB(24, 12, 24, 0),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TabBar(
+            controller: _tabController,
+            tabs: const [Tab(text: '閲覧履歴'), Tab(text: 'PDFキャッシュ')],
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            height: 90,
+            child: IndexedStack(
+              index: _tabController.index,
+              children: [
+                _buildHistoryContent(theme),
+                _buildPdfContent(theme),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          // 共通スライダー
+          Row(
+            children: [
+              Text('$nDaysRound日以上前', style: theme.textTheme.bodySmall),
+              Expanded(
+                child: Slider(
+                  min: 1,
+                  max: 100,
+                  value: _nDays,
+                  onChanged:
+                      _isDeleting ? null : (v) => setState(() => _nDays = v),
+                ),
+              ),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('1日', style: theme.textTheme.labelSmall),
+              Text('100日', style: theme.textTheme.labelSmall),
+            ],
+          ),
+          const SizedBox(height: 4),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isDeleting ? null : () => Navigator.pop(context),
+          child: const Text('キャンセル'),
+        ),
+        TextButton(
+          onPressed: (_isDeleting || !canDeleteBefore) ? null : _onDeleteBefore,
+          child: _isDeleting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text('$nDaysRound日以上前を削除'),
+        ),
+        TextButton(
+          onPressed: _isDeleting ? null : _onDeleteAll,
+          style: TextButton.styleFrom(
+            foregroundColor: theme.colorScheme.error,
+          ),
+          child: const Text('全て削除'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHistoryContent(ThemeData theme) {
+    final total = widget.historyDates.length;
+    final affected = _affectedHistoryCount;
+
+    if (total == 0) {
+      return Center(
+        child: Text('閲覧履歴はありません', style: theme.textTheme.bodyMedium),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('全$total件の閲覧履歴があります'),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Text(
+              '$affected / $total 件が対象',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: affected > 0 ? theme.colorScheme.primary : null,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPdfContent(ThemeData theme) {
+    final total = widget.pdfEntries.length;
+    final totalBytes = _totalPdfBytes;
+    final affectedBytes = _affectedPdfBytes;
+    final ratio = totalBytes > 0 ? affectedBytes / totalBytes : 0.0;
+
+    if (total == 0) {
+      return Center(
+        child: Text('PDFキャッシュはありません', style: theme.textTheme.bodyMedium),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('全$total件 (${_formatBytes(totalBytes)}) のキャッシュがあります'),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: ratio,
+            minHeight: 10,
+            backgroundColor: theme.colorScheme.surfaceContainerHighest,
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '${_formatBytes(affectedBytes)} / ${_formatBytes(totalBytes)} が解放されます',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes < 1024) return '${bytes}B';
+    if (bytes < 1024 * 1024) {
+      return '${(bytes / 1024).toStringAsFixed(1)}KB';
+    }
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+  }
+}

--- a/lib/features/user_archive/data/datasources/pdf_local_data_source.dart
+++ b/lib/features/user_archive/data/datasources/pdf_local_data_source.dart
@@ -3,6 +3,7 @@ import 'package:firebase_storage/firebase_storage.dart';
 
 import "package:kenryo_tankyu/core/constants/work/info_value.dart";
 import 'package:kenryo_tankyu/core/providers/firebase_providers.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/archive_stats.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 
@@ -91,5 +92,53 @@ class PdfLocalDataSource {
     remoteData != null ? await insertPdf(id, remoteData) : null;
 
     return remoteData;
+  }
+
+  Future<void> deleteAllPdf() async {
+    final Database db = await database;
+    await db.delete('works_pdf');
+  }
+
+  Future<void> deletePdfBefore(DateTime date) async {
+    final Database db = await database;
+    await db.delete(
+      'works_pdf',
+      where: 'savedAt < ?',
+      whereArgs: [date.toIso8601String()],
+    );
+  }
+
+  Future<List<PdfCacheEntry>> getAllCacheEntries() async {
+    final Database db = await database;
+    final result = await db.rawQuery(
+      'SELECT savedAt, LENGTH(pdfData) as bytes FROM works_pdf',
+    );
+    return result
+        .map((r) => (
+              date: DateTime.parse(r['savedAt'] as String),
+              bytes: (r['bytes'] as int?) ?? 0,
+            ))
+        .toList();
+  }
+
+  Future<PdfCacheStats> getPdfCacheStats() async {
+    final Database db = await database;
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) as count, SUM(LENGTH(pdfData)) as totalBytes, MIN(savedAt) as oldest, MAX(savedAt) as newest FROM works_pdf',
+    );
+    if (result.isEmpty) {
+      return (count: 0, totalBytes: 0, oldest: null, newest: null);
+    }
+    final row = result[0];
+    final count = (row['count'] as int?) ?? 0;
+    final totalBytes = (row['totalBytes'] as int?) ?? 0;
+    final oldestStr = row['oldest'] as String?;
+    final newestStr = row['newest'] as String?;
+    return (
+      count: count,
+      totalBytes: totalBytes,
+      oldest: oldestStr != null ? DateTime.parse(oldestStr) : null,
+      newest: newestStr != null ? DateTime.parse(newestStr) : null,
+    );
   }
 }

--- a/lib/features/user_archive/data/datasources/searched_history_local_data_source.dart
+++ b/lib/features/user_archive/data/datasources/searched_history_local_data_source.dart
@@ -1,4 +1,5 @@
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/archive_stats.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -177,6 +178,45 @@ class SearchedHistoryLocalDataSource {
       'searched_history',
       where: 'documentID = ?',
       whereArgs: [documentID],
+    );
+  }
+
+  Future<void> deleteAllHistory() async {
+    final Database db = await database;
+    await db.delete('searched_history');
+  }
+
+  Future<void> deleteHistoryBefore(DateTime date) async {
+    final Database db = await database;
+    await db.delete(
+      'searched_history',
+      where: 'savedAt < ?',
+      whereArgs: [date.toIso8601String()],
+    );
+  }
+
+  Future<List<DateTime>> getAllSavedDates() async {
+    final Database db = await database;
+    final result = await db.query('searched_history', columns: ['savedAt']);
+    return result.map((r) => DateTime.parse(r['savedAt'] as String)).toList();
+  }
+
+  Future<HistoryStats> getHistoryStats() async {
+    final Database db = await database;
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) as count, MIN(savedAt) as oldest, MAX(savedAt) as newest FROM searched_history',
+    );
+    if (result.isEmpty) {
+      return (count: 0, oldest: null, newest: null);
+    }
+    final row = result[0];
+    final count = (row['count'] as int?) ?? 0;
+    final oldestStr = row['oldest'] as String?;
+    final newestStr = row['newest'] as String?;
+    return (
+      count: count,
+      oldest: oldestStr != null ? DateTime.parse(oldestStr) : null,
+      newest: newestStr != null ? DateTime.parse(newestStr) : null,
     );
   }
 }

--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -6,6 +6,7 @@ import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_d
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/recommended_works_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/searched_history_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/user_archive_remote_data_source.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/archive_stats.dart';
 import 'package:kenryo_tankyu/features/user_archive/domain/repositories/user_archive_repository.dart';
 
 class UserArchiveRepositoryImpl
@@ -63,6 +64,42 @@ class UserArchiveRepositoryImpl
   Future<void> deleteHistory(int documentID) async {
     try {
       await _historyDataSource.deleteHistory(documentID);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<void> deleteAllHistory() async {
+    try {
+      await _historyDataSource.deleteAllHistory();
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<void> deleteHistoryBefore(DateTime date) async {
+    try {
+      await _historyDataSource.deleteHistoryBefore(date);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<HistoryStats> getHistoryStats() async {
+    try {
+      return await _historyDataSource.getHistoryStats();
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<List<DateTime>> getAllHistorySavedDates() async {
+    try {
+      return await _historyDataSource.getAllSavedDates();
     } catch (e) {
       throw mapException(e);
     }
@@ -185,6 +222,42 @@ class UserArchiveRepositoryImpl
       return await _pdfDataSource
           .getRemotePdfForTeacher(id)
           .timeout(const Duration(seconds: 10));
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<void> deleteAllPdfCache() async {
+    try {
+      await _pdfDataSource.deleteAllPdf();
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<void> deletePdfCacheBefore(DateTime date) async {
+    try {
+      await _pdfDataSource.deletePdfBefore(date);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<PdfCacheStats> getPdfCacheStats() async {
+    try {
+      return await _pdfDataSource.getPdfCacheStats();
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<List<PdfCacheEntry>> getAllPdfCacheEntries() async {
+    try {
+      return await _pdfDataSource.getAllCacheEntries();
     } catch (e) {
       throw mapException(e);
     }

--- a/lib/features/user_archive/domain/models/archive_stats.dart
+++ b/lib/features/user_archive/domain/models/archive_stats.dart
@@ -1,0 +1,8 @@
+typedef HistoryStats = ({int count, DateTime? oldest, DateTime? newest});
+typedef PdfCacheStats = ({
+  int count,
+  int totalBytes,
+  DateTime? oldest,
+  DateTime? newest
+});
+typedef PdfCacheEntry = ({DateTime date, int bytes});

--- a/lib/features/user_archive/domain/repositories/user_archive_repository.dart
+++ b/lib/features/user_archive/domain/repositories/user_archive_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/archive_stats.dart';
 import "package:kenryo_tankyu/core/constants/work/info_value.dart";
 
 abstract class UserArchiveRepository {
@@ -9,6 +10,10 @@ abstract class UserArchiveRepository {
   Future<void> insertHistory(Searched searched);
   Future<Searched?> getHistory(int documentID);
   Future<void> deleteHistory(int documentID);
+  Future<void> deleteAllHistory();
+  Future<void> deleteHistoryBefore(DateTime date);
+  Future<HistoryStats> getHistoryStats();
+  Future<List<DateTime>> getAllHistorySavedDates();
 
   // Favorite (combines local DB and potentially remote updates)
   Future<void> changeFavoriteState(int documentID, bool nextIsFavorite);
@@ -23,6 +28,10 @@ abstract class UserArchiveRepository {
   Future<Uint8List?> getPdf(String id, EnterYear enterYear);
   Future<Uint8List?> getTeacherPdf(String id);
   Future<Uint8List?> getRemotePdfForTeacher(String id);
+  Future<void> deleteAllPdfCache();
+  Future<void> deletePdfCacheBefore(DateTime date);
+  Future<PdfCacheStats> getPdfCacheStats();
+  Future<List<PdfCacheEntry>> getAllPdfCacheEntries();
 
   // Recommended Works
   Future<void> saveRecommendedWorks(Searched searched1, Searched searched2);

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -122,7 +122,38 @@ class HistoryController extends _$HistoryController {
   Future<void> deleteHistory(int id) async {
     final repository = ref.read(userArchiveRepositoryProvider);
     await repository.deleteHistory(id);
+    if (!ref.mounted) return;
     ref.invalidate(searchedHistoryProvider);
+  }
+
+  Future<void> deleteAllHistory() async {
+    final repository = ref.read(userArchiveRepositoryProvider);
+    await repository.deleteAllHistory();
+    if (!ref.mounted) return;
+    ref.invalidate(searchedHistoryProvider);
+  }
+
+  Future<void> deleteHistoryBefore(DateTime date) async {
+    final repository = ref.read(userArchiveRepositoryProvider);
+    await repository.deleteHistoryBefore(date);
+    if (!ref.mounted) return;
+    ref.invalidate(searchedHistoryProvider);
+  }
+}
+
+@riverpod
+class PdfCacheController extends _$PdfCacheController {
+  @override
+  void build() {}
+
+  Future<void> deleteAll() async {
+    final repository = ref.read(userArchiveRepositoryProvider);
+    await repository.deleteAllPdfCache();
+  }
+
+  Future<void> deleteBefore(DateTime date) async {
+    final repository = ref.read(userArchiveRepositoryProvider);
+    await repository.deletePdfCacheBefore(date);
   }
 }
 

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
@@ -149,7 +149,7 @@ final class UserIsFavoriteStateProvider
 }
 
 String _$userIsFavoriteStateHash() =>
-    r'b82606851c4d45565a570aa3fc3382050df14ad2';
+    r'7b0ea0aa4cf8c32da25e818bfbac9396ca605636';
 
 final class UserIsFavoriteStateFamily extends $Family
     with
@@ -302,9 +302,57 @@ final class HistoryControllerProvider
   }
 }
 
-String _$historyControllerHash() => r'5bb6a2466d2600e84fa82192f464ee5109583862';
+String _$historyControllerHash() => r'd85952e0a282f362eb89d41a914b1b8b38090258';
 
 abstract class _$HistoryController extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    build();
+    final ref = this.ref as $Ref<void, void>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<void, void>, void, Object?, Object?>;
+    element.handleValue(ref, null);
+  }
+}
+
+@ProviderFor(PdfCacheController)
+const pdfCacheControllerProvider = PdfCacheControllerProvider._();
+
+final class PdfCacheControllerProvider
+    extends $NotifierProvider<PdfCacheController, void> {
+  const PdfCacheControllerProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'pdfCacheControllerProvider',
+          isAutoDispose: true,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$pdfCacheControllerHash();
+
+  @$internal
+  @override
+  PdfCacheController create() => PdfCacheController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$pdfCacheControllerHash() =>
+    r'969f3994bf6af81a592ef9af351753dd9dffcf07';
+
+abstract class _$PdfCacheController extends $Notifier<void> {
   void build();
   @$mustCallSuper
   @override


### PR DESCRIPTION
## 概要

設定画面から閲覧履歴・PDFキャッシュを削除できる機能を追加。アカウント削除時にすべてのローカルデータを自動消去する処理も追加。あわせてライブラリ画面の長押し削除が履歴リストに反映されないバグを修正。

## 種別
- [x] 機能追加
- [x] バグ修正

## 関連Issue
Closes #

## 変更内容

### 機能追加

**設定画面 → 「履歴の削除」**
- 「閲覧履歴の削除」「PDFキャッシュの削除」の2項目を **「履歴の削除」** 1項目に統合
- タップで開くダイアログに **タブ切り替え**（閲覧履歴 / PDFキャッシュ）を実装
- **スライダー**（1〜100日、デフォルト30日）で削除期間を指定
  - 閲覧履歴タブ：スライダーに連動して「X / Y件が対象」をリアルタイム表示
  - PDFキャッシュタブ：スライダーに連動してゲージバー＋「X MB / Y MB が解放されます」をリアルタイム表示
- ボタン2択：「N日以上前を削除」「全て削除（赤）」

**アカウント削除時の全ローカルデータ消去**
- `AuthNotifier.deleteAccount()` 成功後に4テーブルを自動消去
  - `searched_history`（閲覧履歴）
  - `works_pdf`（PDFキャッシュ）
  - `search_history`（検索履歴）
  - `notification`（通知履歴）

### バグ修正

**ライブラリ長押し削除が即座にリストへ反映されない問題**
- `result_preview_content.dart` の「消去」ボタン `onPressed` が `deleteHistory()` を `await` せず `Navigator.pop()` していたため、削除完了前にリストが表示される競合が発生していた
- `await` を追加し、DB削除とプロバイダ無効化が完了してからダイアログを閉じるよう修正

**`HistoryController` の `ref.invalidate` エラー**
- `@riverpod`（auto-dispose）Notifier の async gap 後に `ref` が破棄済みになる問題
- 各メソッドの `await` 後に `if (!ref.mounted) return;` を追加

### 追加ファイル・主な変更ファイル
- `lib/features/settings/presentation/widgets/delete_data_dialog.dart`（新規）
- `lib/features/user_archive/domain/models/archive_stats.dart`（新規：`HistoryStats` / `PdfCacheStats` / `PdfCacheEntry` typedef）
- `UserArchiveRepository` / `Impl` に削除・統計系メソッドを追加
- `SearchedHistoryLocalDataSource` / `PdfLocalDataSource` に対応SQLiteクエリを追加
- `NotificationDbController` に `deleteAllNotifications()` を追加

## スクリーンショット

（実機確認済み）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし（`flutter analyze`: No issues found）
- [ ] テストを追加または更新済み（必要な場合）