### PR TITLE
[Search] 絞り込み条件の改善 (#133)

### DIFF
--- a/lib/core/constants/work/info_value.dart
+++ b/lib/core/constants/work/info_value.dart
@@ -9,6 +9,11 @@ enum EnterYear {
 
   final int displayName;
   const EnterYear({required this.displayName});
+
+  String get label {
+    if (this == EnterYear.undefined) return '指定なし';
+    return '$displayName年度入学';
+  }
 }
 
 class EnterYearEnumConverter implements JsonConverter<EnterYear, int> {

--- a/lib/core/constants/work/info_value.dart
+++ b/lib/core/constants/work/info_value.dart
@@ -5,6 +5,8 @@ enum EnterYear {
   enter2021(displayName: 2021),
   enter2022(displayName: 2022),
   enter2023(displayName: 2023),
+  enter2024(displayName: 2024),
+  enter2025(displayName: 2025),
   undefined(displayName: 0);
 
   final int displayName;

--- a/lib/features/search/presentation/screens/search_page.dart
+++ b/lib/features/search/presentation/screens/search_page.dart
@@ -144,7 +144,6 @@ class SearchPage extends ConsumerWidget {
         data.category == Category.none &&
         data.subCategory == SubCategory.none &&
         data.enterYear == EnterYear.undefined &&
-        data.eventName == EventName.undefined &&
         data.course == Course.undefined;
     if (isAllEmpty) {
       return const SizedBox();

--- a/lib/features/search/presentation/widgets/drop_button.dart
+++ b/lib/features/search/presentation/widgets/drop_button.dart
@@ -55,15 +55,10 @@ class SearchDropButton extends ConsumerWidget {
     final selectedValue = value ?? '';
 
     switch (name) {
-      case '期間':
+      case '年度指定':
         notifier.selectedYear(EnterYear.values.firstWhere(
-            (element) => element.displayName.toString() == selectedValue,
+            (element) => element.label == selectedValue,
             orElse: () => EnterYear.undefined));
-        break;
-      case 'イベント名':
-        notifier.selectedEventName(EventName.values.firstWhere(
-            (element) => element.displayName == selectedValue,
-            orElse: () => EventName.undefined));
         break;
       case '学科指定':
         notifier.selectedCourse(Course.values.firstWhere(

--- a/lib/features/search/presentation/widgets/search_chip_list.dart
+++ b/lib/features/search/presentation/widgets/search_chip_list.dart
@@ -22,21 +22,16 @@ class SearchChipList extends ConsumerWidget {
         final displaySubCategory = data.subCategory != SubCategory.none
             ? data.subCategory.displayName
             : '';
-        final displayEventName = data.eventName != EventName.undefined
-            ? data.eventName.displayName
-            : '';
         final displayCourse =
             data.course != Course.undefined ? data.course.displayName : '';
-        final displayEnterYear = data.enterYear != EnterYear.undefined
-            ? data.enterYear.displayName
-            : '';
+        final displayEnterYear =
+            data.enterYear != EnterYear.undefined ? data.enterYear.label : '';
         final List<String> items = data.searchWord;
 
         final List<List<String>> searchList = [
           ['category', displayCategory],
           ['subCategory', displaySubCategory],
-          ['year', displayEnterYear.toString()],
-          ['eventName', displayEventName],
+          ['year', displayEnterYear],
           ['course', displayCourse],
         ];
         final bool isAllEmpty =

--- a/lib/features/search/presentation/widgets/search_history_list.dart
+++ b/lib/features/search/presentation/widgets/search_history_list.dart
@@ -81,11 +81,8 @@ class SearchHistoryList extends ConsumerWidget {
     search.subCategory != SubCategory.none
         ? searchList.add(search.subCategory.displayName)
         : null;
-    search.enterYear.displayName != 0
-        ? searchList.add(search.enterYear.displayName.toString())
-        : null;
-    search.eventName != EventName.undefined
-        ? searchList.add(search.eventName.displayName)
+    search.enterYear != EnterYear.undefined
+        ? searchList.add(search.enterYear.label)
         : null;
     search.course != Course.undefined
         ? searchList.add(search.course.displayName)

--- a/lib/features/search/presentation/widgets/sidebar.dart
+++ b/lib/features/search/presentation/widgets/sidebar.dart
@@ -43,13 +43,9 @@ class SideBar extends ConsumerWidget {
                       const SizedBox(height: 10.0),
                       SearchDropButton(
                           name: '年度指定',
-                          selectedText: data.enterYear != EnterYear.undefined
-                              ? data.enterYear.label
-                              : null,
-                          choices: EnterYear.values
-                              .where((e) => e != EnterYear.undefined)
-                              .map((e) => e.label)
-                              .toList()),
+                          selectedText: data.enterYear.label,
+                          choices:
+                              EnterYear.values.map((e) => e.label).toList()),
                       const SizedBox(height: 15.0),
                       SearchDropButton(
                           name: '学科指定',

--- a/lib/features/search/presentation/widgets/sidebar.dart
+++ b/lib/features/search/presentation/widgets/sidebar.dart
@@ -42,24 +42,13 @@ class SideBar extends ConsumerWidget {
                     children: [
                       const SizedBox(height: 10.0),
                       SearchDropButton(
-                          name: 'カテゴリ',
-                          selectedText: data.category.displayName,
-                          choices: Category.values
-                              .map((e) => e.displayName)
-                              .toList()),
-                      const SizedBox(height: 15.0),
-                      SearchDropButton(
-                          name: '期間',
-                          selectedText: data.enterYear.displayName.toString(),
+                          name: '年度指定',
+                          selectedText: data.enterYear != EnterYear.undefined
+                              ? data.enterYear.label
+                              : null,
                           choices: EnterYear.values
-                              .map((e) => e.displayName.toString())
-                              .toList()),
-                      const SizedBox(height: 15.0),
-                      SearchDropButton(
-                          name: 'イベント名',
-                          selectedText: data.eventName.displayName,
-                          choices: EventName.values
-                              .map((e) => e.displayName)
+                              .where((e) => e != EnterYear.undefined)
+                              .map((e) => e.label)
                               .toList()),
                       const SizedBox(height: 15.0),
                       SearchDropButton(
@@ -67,6 +56,13 @@ class SideBar extends ConsumerWidget {
                           selectedText: data.course.displayName,
                           choices:
                               Course.values.map((e) => e.displayName).toList()),
+                      const SizedBox(height: 15.0),
+                      SearchDropButton(
+                          name: 'カテゴリ',
+                          selectedText: data.category.displayName,
+                          choices: Category.values
+                              .map((e) => e.displayName)
+                              .toList()),
                       const SizedBox(height: 15.0),
                       const Text('サブカテゴリを選択'),
                       data.category != Category.none

--- a/lib/features/search/presentation/widgets/sub_category_chip.dart
+++ b/lib/features/search/presentation/widgets/sub_category_chip.dart
@@ -27,8 +27,13 @@ class SubCategoryChip extends ConsumerWidget {
             label: Text(exactSubCategoryList[index].displayName),
             selected:
                 exactSubCategoryList.indexOf(selectedSubCategory) == index,
-            onSelected: (_) =>
-                notifier.selectedSubCategory(exactSubCategoryList[index]));
+            onSelected: (_) {
+              if (selectedSubCategory == exactSubCategoryList[index]) {
+                notifier.selectedSubCategory(SubCategory.none);
+              } else {
+                notifier.selectedSubCategory(exactSubCategoryList[index]);
+              }
+            });
       }).toList(),
     );
   }


### PR DESCRIPTION
## 概要
絞り込み条件のUI改善。イベント名フィルター削除、年度表示の改善、サブカテゴリのトグル対応、表示順の変更。

## 種別
- [x] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #133

## 変更内容
- イベント名フィルターを削除（「個人探究」「信州学」の区別がないため）
- 「期間」を「年度指定」に改名し、表示を「2020年度入学」形式に変更、ドロップダウンに「指定なし」を含め選択解除できるよう対応
- 2024・2025年度入学を追加
- サブカテゴリを再タップで選択解除できるよう変更
- 絞り込みの表示順を「年度指定 → 学科指定 → カテゴリ → サブカテゴリ」に変更

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）