### PR TITLE
[fix] ResultPreviewContentのクリック範囲拡大・いいね制御・forLibraryリファクタリング

### DIFF
--- a/lib/features/search/presentation/widgets/result_list_preview.dart
+++ b/lib/features/search/presentation/widgets/result_list_preview.dart
@@ -19,12 +19,10 @@ class ResultList extends ConsumerWidget {
         child: ListView.separated(
           itemBuilder: (BuildContext context, int index) {
             final Searched searched = data[index];
-            return Consumer(builder: (context, ref, child) {
-              return ResultPreviewContent(
-                searched: searched,
-                mode: ResultPreviewMode.search,
-              );
-            });
+            return ResultPreviewContent(
+              searched: searched,
+              mode: ResultPreviewMode.search,
+            );
           },
           separatorBuilder: (BuildContext context, int index) {
             return const Padding(

--- a/lib/features/search/presentation/widgets/result_list_preview.dart
+++ b/lib/features/search/presentation/widgets/result_list_preview.dart
@@ -22,7 +22,7 @@ class ResultList extends ConsumerWidget {
             return Consumer(builder: (context, ref, child) {
               return ResultPreviewContent(
                 searched: searched,
-                forLibrary: false,
+                mode: ResultPreviewMode.search,
               );
             });
           },

--- a/lib/features/search/presentation/widgets/result_preview_content.dart
+++ b/lib/features/search/presentation/widgets/result_preview_content.dart
@@ -19,7 +19,7 @@ class ResultPreviewContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: () async {
+      onTap: () {
         context.push('/result/${searched.documentID}');
       },
       onLongPress: mode == ResultPreviewMode.library

--- a/lib/features/search/presentation/widgets/result_preview_content.dart
+++ b/lib/features/search/presentation/widgets/result_preview_content.dart
@@ -7,22 +7,23 @@ import 'package:kenryo_tankyu/features/search/presentation/widgets/image_chip.da
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/widgets/favorite_button.dart';
 
+enum ResultPreviewMode { search, library }
+
 class ResultPreviewContent extends ConsumerWidget {
   final Searched searched;
-  final bool forLibrary;
+  final ResultPreviewMode mode;
   const ResultPreviewContent(
-      {super.key, required this.searched, required this.forLibrary});
+      {super.key, required this.searched, required this.mode});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: () async {
-        ///詳細画面への遷移と、履歴の追加
         context.push('/result/${searched.documentID}');
       },
-      onLongPress: forLibrary
+      onLongPress: mode == ResultPreviewMode.library
           ? () async {
-              ///履歴の消去
               showDialog(
                 context: context,
                 builder: (context) {
@@ -86,7 +87,11 @@ class ResultPreviewContent extends ConsumerWidget {
                 ),
                 Padding(
                   padding: const EdgeInsets.only(top: 8.0, left: 4.0),
-                  child: FavoriteButton(searched: searched, isLarge: false),
+                  child: FavoriteButton(
+                    searched: searched,
+                    isLarge: false,
+                    enabled: mode == ResultPreviewMode.library,
+                  ),
                 ),
               ],
             ),

--- a/lib/features/user_archive/presentation/widgets/favorite_button.dart
+++ b/lib/features/user_archive/presentation/widgets/favorite_button.dart
@@ -11,11 +11,13 @@ import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_
 class FavoriteButton extends ConsumerStatefulWidget {
   final Searched searched;
   final bool isLarge;
+  final bool enabled;
 
   const FavoriteButton({
     super.key,
     required this.searched,
     this.isLarge = false,
+    this.enabled = true,
   });
 
   @override
@@ -96,6 +98,10 @@ class _FavoriteButtonState extends ConsumerState<FavoriteButton> {
             )
           : content,
     );
+
+    if (!widget.enabled) {
+      return buttonBase;
+    }
 
     return InkWell(
       onTap: isLoading

--- a/lib/features/user_archive/presentation/widgets/history_list.dart
+++ b/lib/features/user_archive/presentation/widgets/history_list.dart
@@ -41,7 +41,7 @@ class LibraryList extends ConsumerWidget {
                           final searched = searcheds[index];
                           return ResultPreviewContent(
                             searched: searched,
-                            forLibrary: true,
+                            mode: ResultPreviewMode.library,
                           );
                         });
                       },

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -94,13 +94,13 @@ class _HomePageState extends ConsumerState<HomePage> {
                           Card(
                             child: ResultPreviewContent(
                               searched: data[0],
-                              forLibrary: false,
+                              mode: ResultPreviewMode.search,
                             ),
                           ),
                           Card(
                             child: ResultPreviewContent(
                               searched: data[1],
-                              forLibrary: false,
+                              mode: ResultPreviewMode.search,
                             ),
                           ),
                         ],


### PR DESCRIPTION
## 概要
探究作品一覧のカードUIに関する2点の修正とリファクタリングを行う。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #136

## 変更内容
- **クリック範囲の修正**: `ResultPreviewContent` の `GestureDetector` に `behavior: HitTestBehavior.opaque` を追加。カード内の空白部分でもタップが反応するように修正。
- **いいねボタンの制御**: `FavoriteButton` に `enabled` パラメータを追加。検索画面・ホーム画面ではいいね操作を無効化し、ライブラリ画面（閲覧履歴・お気に入り）のみ切り替え可能に変更。
- **`forLibrary` のリファクタリング**: `bool forLibrary` を `ResultPreviewMode` enum（`search` / `library`）に置き換え。コンテキストが名前から明確になり、将来的なモード追加もしやすい構造に改善。

## スクリーンショット
（動作確認済みだが、エミュレータ未起動のためスクリーンショットは省略）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）