### PR TITLE
[Search] 画面遷移アニメーションのUX改善とrouter.dartの整理

### DIFF
--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -3,24 +3,34 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
 
+// Auth
 import 'package:kenryo_tankyu/features/auth/presentation/screens/welcome_page.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/screens/create_password_page.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/screens/verify_name_page.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/screens/login_page.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/screens/reset_password_page.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/screens/verify_email_page.dart';
-import 'package:kenryo_tankyu/features/notification/presentation/screens/notification_page.dart';
-import 'package:kenryo_tankyu/features/research_work/presentation/screens/result_page.dart';
+
+// Search
+import 'package:kenryo_tankyu/features/search/presentation/screens/category_select_page.dart';
 import 'package:kenryo_tankyu/features/search/presentation/screens/result_list_page.dart';
 import 'package:kenryo_tankyu/features/search/presentation/screens/search_page.dart';
 import 'package:kenryo_tankyu/features/search/presentation/screens/sub_category_select_page.dart';
+
+// Features
+import 'package:kenryo_tankyu/features/notification/presentation/screens/notification_page.dart';
+import 'package:kenryo_tankyu/features/research_work/presentation/screens/result_page.dart';
 import 'package:kenryo_tankyu/features/settings/presentation/screens/settings_page.dart';
 import 'package:kenryo_tankyu/features/teacher/presentation/screens/show_teacher_pdf.dart';
 import 'package:kenryo_tankyu/features/teacher/presentation/screens/teacher_select_page.dart';
+
+// Shell (BottomNavigationBar)
 import 'package:kenryo_tankyu/presentation/screens/home_page.dart';
 import 'package:kenryo_tankyu/presentation/screens/explore_page.dart';
 import 'package:kenryo_tankyu/presentation/screens/library_page.dart';
 import 'package:kenryo_tankyu/presentation/widget/widget.dart';
+
+// Dev / Test
 import 'package:kenryo_tankyu/test/test_file_select.dart';
 import 'package:kenryo_tankyu/test/test_for_aoi.dart';
 import 'package:kenryo_tankyu/test/test_for_coji.dart';
@@ -56,34 +66,70 @@ final routesProvider = Provider<GoRouter>((ref) {
       return null;
     },
     routes: [
+      // ─── 認証フロー ───────────────────────────────────────────
       GoRoute(
-          path: '/welcome',
-          builder: (context, state) => const WelcomePage(),
-          routes: [
-            GoRoute(
-                path: 'verify_name',
-                builder: (context, state) => const VerifyNamePage(),
-                routes: [
-                  GoRoute(
-                    path: 'create_password',
-                    builder: (context, state) => const CreatePassWordPage(),
-                  ),
-                ]),
-            GoRoute(
-                path: 'login',
-                builder: (context, state) =>
-                    LoginPage(isDeveloper: state.extra as bool? ?? false),
-                routes: [
-                  GoRoute(
-                    path: 'reset_password',
-                    builder: (context, state) => const ResetPasswordPage(),
-                  )
-                ]),
-          ]),
+        path: '/welcome',
+        builder: (context, state) => const WelcomePage(),
+        routes: [
+          GoRoute(
+            path: 'verify_name',
+            builder: (context, state) => const VerifyNamePage(),
+            routes: [
+              GoRoute(
+                path: 'create_password',
+                builder: (context, state) => const CreatePassWordPage(),
+              ),
+            ],
+          ),
+          GoRoute(
+            path: 'login',
+            builder: (context, state) =>
+                LoginPage(isDeveloper: state.extra as bool? ?? false),
+            routes: [
+              GoRoute(
+                path: 'reset_password',
+                builder: (context, state) => const ResetPasswordPage(),
+              ),
+            ],
+          ),
+        ],
+      ),
       GoRoute(
         path: '/verify_email',
         builder: (context, state) => const CheckEmailPage(),
       ),
+
+      // ─── 検索フロー ───────────────────────────────────────────
+      // 遷移順: /search → /categorySelect → /subCategory → /resultList
+      //         /search → /subCategory → /resultList
+      //         /explore(shell) → /subCategory → /resultList
+      GoRoute(
+        path: '/search',
+        builder: (context, state) => const SearchPage(),
+      ),
+      GoRoute(
+        path: '/categorySelect',
+        builder: (context, state) => const CategorySelectPage(),
+      ),
+      GoRoute(
+        path: '/subCategory',
+        builder: (context, state) => const SubCategorySelectPage(),
+      ),
+      GoRoute(
+        path: '/resultList',
+        builder: (context, state) => ResultListPage(),
+      ),
+
+      // ─── 作品詳細 ─────────────────────────────────────────────
+      GoRoute(
+        path: '/result/:documentID',
+        builder: (context, state) {
+          final documentID = state.pathParameters['documentID']!;
+          return ResultPage(documentID: int.parse(documentID));
+        },
+      ),
+
+      // ─── その他の機能 ─────────────────────────────────────────
       GoRoute(
         path: '/settings',
         builder: (context, state) => const SettingsPage(),
@@ -93,44 +139,22 @@ final routesProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const NotificationPage(),
       ),
       GoRoute(
-        path: '/result/:documentID',
-        builder: (context, state) {
-          final documentID = state.pathParameters['documentID']!;
-          return ResultPage(documentID: int.parse(documentID));
-        },
-      ),
-      GoRoute(
-          path: '/teacher',
-          pageBuilder: (context, state) =>
-              const NoTransitionPage(child: TeacherSelectPage()),
-          routes: <RouteBase>[
-            GoRoute(
-              path: 'showPdf',
-              builder: (context, state) => const ShowTeacherPdfPage(),
-            ),
-          ]),
-
-      GoRoute(
-        path: '/resultList',
-        builder: (context, state) => ResultListPage(),
-      ),
-      GoRoute(
-        path: '/subCategory',
-        builder: (context, state) => const SubCategorySelectPage(),
-      ),
-      GoRoute(
-        path: '/search',
-        builder: (context, state) => const SearchPage(),
+        path: '/teacher',
+        pageBuilder: (context, state) =>
+            const NoTransitionPage(child: TeacherSelectPage()),
+        routes: [
+          GoRoute(
+            path: 'showPdf',
+            builder: (context, state) => const ShowTeacherPdfPage(),
+          ),
+        ],
       ),
 
-      //ShellRoute内にBottomNavigationBarで遷移する画面を記載する
+      // ─── BottomNavigationBar (ShellRoute) ────────────────────
       ShellRoute(
         navigatorKey: _shellNavigatorKey,
-        //BottomNavigationBarを実装しているページを記載する
-        //childでScaffoldのbodyを渡す
         builder: (context, state, child) => Footer(child: child),
-        routes: <RouteBase>[
-          //BottomNavigationBarから遷移するページを記載する
+        routes: [
           GoRoute(
             path: '/home',
             pageBuilder: (context, state) =>
@@ -146,19 +170,25 @@ final routesProvider = Provider<GoRouter>((ref) {
             pageBuilder: (context, state) =>
                 NoTransitionPage(child: LibraryPage(key: state.pageKey)),
           ),
+
+          // ─── 開発用テスト画面 ────────────────────────────────
           GoRoute(
             path: '/testSelect',
             pageBuilder: (context, state) =>
                 NoTransitionPage(child: TestSelectPage(key: state.pageKey)),
-            routes: <RouteBase>[
+            routes: [
               GoRoute(
-                  path: 'mitsuki',
-                  builder: (context, state) => const TestForMitsuki()),
+                path: 'mitsuki',
+                builder: (context, state) => const TestForMitsuki(),
+              ),
               GoRoute(
-                  path: 'coji',
-                  builder: (context, state) => const TestForCoji()),
+                path: 'coji',
+                builder: (context, state) => const TestForCoji(),
+              ),
               GoRoute(
-                  path: 'aoi', builder: (context, state) => const TestForAoi()),
+                path: 'aoi',
+                builder: (context, state) => const TestForAoi(),
+              ),
             ],
           ),
         ],

--- a/lib/features/search/presentation/screens/category_select_page.dart
+++ b/lib/features/search/presentation/screens/category_select_page.dart
@@ -8,7 +8,7 @@ class CategorySelectPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('カテゴリから選ぶ'),
+        title: const Text('カテゴリーを選択'),
         backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
       ),
       body: const CategoryList(),

--- a/lib/features/search/presentation/screens/category_select_page.dart
+++ b/lib/features/search/presentation/screens/category_select_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:kenryo_tankyu/features/search/presentation/widgets/category.dart';
+
+class CategorySelectPage extends StatelessWidget {
+  const CategorySelectPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('カテゴリから選ぶ'),
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
+      ),
+      body: const CategoryList(),
+    );
+  }
+}

--- a/lib/features/search/presentation/screens/search_page.dart
+++ b/lib/features/search/presentation/screens/search_page.dart
@@ -12,7 +12,6 @@ import 'package:kenryo_tankyu/features/search/presentation/widgets/search_header
 import 'package:kenryo_tankyu/features/search/presentation/widgets/search_chip_list.dart';
 import 'package:kenryo_tankyu/features/search/presentation/widgets/search_history_list.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
-import 'package:kenryo_tankyu/presentation/widget/widget.dart';
 
 class SearchPage extends ConsumerWidget {
   const SearchPage({super.key});
@@ -64,8 +63,7 @@ class SearchPage extends ConsumerWidget {
                     title: const Text('またはカテゴリから選ぶ'),
                     trailing: const Icon(Icons.navigate_next),
                     onTap: () {
-                      ref.read(footerProvider.notifier).state = 1;
-                      context.go('/explore');
+                      context.push('/categorySelect');
                     },
                   );
                 }
@@ -130,11 +128,11 @@ class SearchPage extends ConsumerWidget {
     final notifier = ref.read(searchProvider.notifier);
     if (suggestCategory != Category.none) {
       notifier.selectedCategory(suggestCategory);
-      context.pushReplacement('/subCategory');
+      context.push('/subCategory');
     } else {
       notifier.selectedCategory(whatCategory);
       notifier.selectedSubCategory(suggestSubCategory);
-      context.pushReplacement('/resultList');
+      context.push('/resultList');
     }
   }
 
@@ -165,7 +163,7 @@ class SearchPage extends ConsumerWidget {
             trailing: IconButton(
               icon: const Icon(Icons.search_sharp),
               onPressed: () {
-                context.pushReplacement('/resultList');
+                context.push('/resultList');
               },
             ),
           ),

--- a/lib/features/search/presentation/widgets/display_sub_category_list.dart
+++ b/lib/features/search/presentation/widgets/display_sub_category_list.dart
@@ -18,7 +18,7 @@ class DisplaySubCategoryList extends ConsumerWidget {
         ListTile(
           title: const Text('すべて'),
           trailing: const Icon(Icons.navigate_next),
-          onTap: () => context.pushReplacement('/resultList'),
+          onTap: () => context.push('/resultList'),
         ),
         const Padding(
           padding: EdgeInsets.only(left: 8.0, right: 8.0),
@@ -37,7 +37,7 @@ class DisplaySubCategoryList extends ConsumerWidget {
                   title: Text(subCategoryList[index].displayName),
                   onTap: () {
                     notifier.selectedSubCategory(subCategoryList[index]);
-                    context.pushReplacement('/resultList');
+                    context.push('/resultList');
                   },
                 ),
               );

--- a/lib/features/search/presentation/widgets/result_header.dart
+++ b/lib/features/search/presentation/widgets/result_header.dart
@@ -7,7 +7,6 @@ import 'package:kenryo_tankyu/features/search/presentation/widgets/search_chip_l
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
-import 'package:kenryo_tankyu/presentation/widget/widget.dart';
 
 class ResultHeader extends ConsumerStatefulWidget
     implements PreferredSizeWidget {
@@ -42,7 +41,7 @@ class ResultHeaderState extends ConsumerState<ResultHeader> {
         child: SizedBox(
           height: 40,
           child: InkWell(
-            onTap: () => context.pushReplacement('/search'),
+            onTap: () => context.pop(),
             child: Container(
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.surfaceContainerHighest,
@@ -67,24 +66,12 @@ class ResultHeaderState extends ConsumerState<ResultHeader> {
 
   void _backTo(BuildContext context) {
     final notifier = ref.read(searchProvider.notifier);
-    final footerNotifier = ref.read(footerProvider.notifier);
     final Search searchStatus = ref.watch(searchProvider);
-    //優先順位は上から順
-    //ユーザーが入力した単語が入っている場合→キーワード入力画面(/search)まで戻る
-    //サブカテゴリーが入っている場合→サブカテゴリ選択画面(/subCategory)まで戻る
-    //カテゴリのみ選択されている場合→カテゴリ選択画面(/explore)まで戻る
-    if (searchStatus.searchWord.isNotEmpty) {
-      context.go('/search');
-    } else if (searchStatus.subCategory != SubCategory.none) {
+    if (searchStatus.subCategory != SubCategory.none) {
       notifier.deleteParameter('subCategory');
-      context.go('/subCategory');
     } else if (searchStatus.category != Category.none) {
       notifier.deleteAllParameters();
-      footerNotifier.state = 1;
-      context.go('/explore');
-    } else {
-      footerNotifier.state = 0;
-      context.go('/home');
     }
+    context.pop();
   }
 }

--- a/lib/features/search/presentation/widgets/result_header.dart
+++ b/lib/features/search/presentation/widgets/result_header.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import "package:kenryo_tankyu/core/constants/work/category_value.dart";
 import "package:kenryo_tankyu/core/constants/work/sub_category_value.dart";
 import 'package:kenryo_tankyu/features/search/presentation/widgets/search_chip_list.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
@@ -66,11 +65,9 @@ class ResultHeaderState extends ConsumerState<ResultHeader> {
 
   void _backTo(BuildContext context) {
     final notifier = ref.read(searchProvider.notifier);
-    final Search searchStatus = ref.watch(searchProvider);
+    final Search searchStatus = ref.read(searchProvider);
     if (searchStatus.subCategory != SubCategory.none) {
       notifier.deleteParameter('subCategory');
-    } else if (searchStatus.category != Category.none) {
-      notifier.deleteAllParameters();
     }
     context.pop();
   }

--- a/lib/features/search/presentation/widgets/search_header.dart
+++ b/lib/features/search/presentation/widgets/search_header.dart
@@ -85,7 +85,7 @@ class _SearchHeaderState extends ConsumerState<SearchHeader> {
         content == '　'); //検索ワードに余分に空白が入っていた場合、消去する todo しっかり機能していないかも。
     notifier.addKeyWord(word);
     //検索結果画面に遷移
-    context.pushReplacement('/resultList');
+    context.push('/resultList');
   }
 
   void _onChanged(String text) {

--- a/lib/features/search/presentation/widgets/search_history_list.dart
+++ b/lib/features/search/presentation/widgets/search_history_list.dart
@@ -53,7 +53,7 @@ class SearchHistoryList extends ConsumerWidget {
                             ref
                                 .read(searchProvider.notifier)
                                 .setParameters(search);
-                            context.pushReplacement('/resultList');
+                            context.push('/resultList');
                           });
                     },
                     separatorBuilder: (BuildContext context, int index) {

--- a/lib/features/search/presentation/widgets/sub_category_select_header.dart
+++ b/lib/features/search/presentation/widgets/sub_category_select_header.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 import "package:kenryo_tankyu/core/constants/work/category_value.dart";
 import "package:kenryo_tankyu/core/constants/work/sub_category_value.dart";
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
-import 'package:kenryo_tankyu/presentation/widget/widget.dart';
 
 class SubCategorySelectHeader extends ConsumerWidget
     implements PreferredSizeWidget {
@@ -24,8 +23,7 @@ class SubCategorySelectHeader extends ConsumerWidget
           ref.read(suggestSubCategoryProvider.notifier).state =
               SubCategory.none;
           ref.read(searchProvider.notifier).deleteAllParameters();
-          ref.read(footerProvider.notifier).state = 1;
-          context.go('/explore');
+          context.pop();
         },
       ),
       backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,


### PR DESCRIPTION
## 概要
検索フローにおける画面遷移アニメーションの方向が不正になっていた問題を修正し、router.dart の可読性を向上。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #127

## 変更内容

### 問題1: 「またはカテゴリから選ぶ」が戻るアニメーションになっていた
- `SearchPage` の「またはカテゴリから選ぶ」ボタンが `context.go('/explore')` でShellRouteに戻っていたため、戻る（左から）アニメーションになっていた
- 新規 `CategorySelectPage` を作成し、`context.push('/categorySelect')` で前進（右から）アニメーションに変更

### 問題2: 検索結果から戻る時に前進アニメーションになっていた
- `context.pushReplacement('/resultList')` を `context.push('/resultList')` に変更し、戻るスタックを正しく維持
  - 対象: `SearchPage`、`SearchHeader`、`SearchHistoryList`、`DisplaySubCategoryList`
- `ResultHeader._backTo()` の `context.go('/xxx')` を `context.pop()` に変更
- `SubCategorySelectHeader` の戻るボタンも `context.go('/explore')` から `context.pop()` に変更

### 問題3: router.dart の整理
- 認証・検索・作品詳細・その他機能・ShellRoute をセクション別コメントで分類
- 検索フローの遷移順をコメントで明記
- インポートをグループ別に整理

## スクリーンショット
なし（アニメーション方向の修正のため）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）