### PR TITLE
[fix] Firebase CLIのキャッシュ・ログをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ app.*.map.json
 
 # AI prompt
 /CLAUDE.md
+
+# Firebase CLI
+.firebase/
+firepit-log.txt

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1461,6 +1461,8 @@ PODS:
     - Flutter
   - screenshot_callback (0.0.1):
     - Flutter
+  - share_plus (0.0.1):
+    - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -1486,6 +1488,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - screen_capture_event (from `.symlinks/plugins/screen_capture_event/ios`)
   - screenshot_callback (from `.symlinks/plugins/screenshot_callback/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -1552,6 +1555,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/screen_capture_event/ios"
   screenshot_callback:
     :path: ".symlinks/plugins/screenshot_callback/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
@@ -1564,14 +1569,14 @@ SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 56865cb5aaf44141583c4ee957be36f6af72178d
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
-  external_path: 2594f1f0d6afcff9e202cfe9c8908dd605b86f32
+  cloud_firestore: 7a6d8a533ec7418a7fe46b3a5dabf55661a5b298
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  external_path: fd37c654b69a1336e33a2403f48383ae6100e443
   Firebase: f07b15ae5a6ec0f93713e30b923d9970d144af3e
-  firebase_auth: 4816610b91e98ca2f48df6c62e0247036e0856ff
-  firebase_core: e6b8bb503b7d1d9856e698d4f193f7b414e6bf1f
-  firebase_messaging: fc7b6af84f4cd885a4999f51ea69ef20f380d70d
-  firebase_storage: 0cb7ceae9496b643ffe734ba2645b8b7339b0cc4
+  firebase_auth: 9225db04db5d8e3b46dc8940e04bc6aec6833e27
+  firebase_core: f1aafb21c14f497e5498f7ffc4dc63cbb52b2594
+  firebase_messaging: c17a29984eafce4b2997fe078bb0a9e0b06f5dde
+  firebase_storage: d558bbfa99449fff39352db83c466c8515fa1afa
   FirebaseAppCheckInterop: f734c802f21fe1da0837708f0f9a27218c8a4ed0
   FirebaseAuth: 4a2aed737c84114a9d9b33d11ae1b147d6b94889
   FirebaseAuthInterop: 858e6b754966e70740a4370dd1503dfffe6dbb49
@@ -1585,9 +1590,9 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 93426a1de92f19e1199fac5295a4f8df16458daa
   FirebaseStorage: 20d6b56fb8a40ebaa03d6a2889fe33dac64adb73
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
-  flutter_pdfview: 2e4d13ffb774858562ffbdfdb61b40744b191adc
-  google_sign_in_ios: 055d43c4754f2860a53decd5133b78d05615fffd
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_pdfview: 32bf27bda6fd85b9dd2c09628a824df5081246cf
+  google_sign_in_ios: 00dfa94252eb10278b64828c81bcb7158a81a53a
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: c7f09cfbc85a1abf69187be091997c317cc33b77
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
@@ -1597,15 +1602,16 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  screen_capture_event: bcf965bb31968a51c08ad3698725c5ad8c597124
-  screenshot_callback: b173e7f4bd8d2ef14a9a5e5a77c0ac6a47578608
-  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  screen_capture_event: efc4eb455e1c5cc304cec85a4372e0a633ff2a7c
+  screenshot_callback: 85707df1b45a59407f7de87de2408c2f5312a473
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: 1857a7cdb7dfafe45f2b0e9a9af44644190f7506
 


### PR DESCRIPTION
## 概要
Firebase CLI が生成するキャッシュ・ログファイルをgitignoreに追加。

## 種別
- [ ] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明）

## 関連Issue
なし

## 変更内容
- `.firebase/` — Firebase Hosting のキャッシュディレクトリ
- `firepit-log.txt` — Firebase CLI のログファイル

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）