### PR TITLE
[fix] メール確認ページに「最初からやり直す」ボタンを追加

### DIFF
--- a/lib/features/auth/presentation/screens/verify_email_page.dart
+++ b/lib/features/auth/presentation/screens/verify_email_page.dart
@@ -1,6 +1,7 @@
 import 'package:kenryo_tankyu/core/providers/firebase_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import "package:kenryo_tankyu/core/constants/app_unique_value.dart";
 import 'package:kenryo_tankyu/core/constants/feature/user_value.dart';
@@ -75,6 +76,10 @@ class CheckEmailPage extends ConsumerWidget {
                   ),
                 ),
                 const SizedBox(height: 20),
+                TextButton(
+                  onPressed: () => _restartFromBeginning(context, ref),
+                  child: const Text('最初からやり直す'),
+                ),
               ],
             ),
           ),
@@ -99,6 +104,12 @@ class CheckEmailPage extends ConsumerWidget {
         ),
       );
     }
+  }
+
+  _restartFromBeginning(BuildContext context, WidgetRef ref) async {
+    await ref.read(authProvider.notifier).signOut();
+    if (!context.mounted) return;
+    context.go('/welcome');
   }
 
   _reload(BuildContext context, WidgetRef ref) async {


### PR DESCRIPTION
## 概要
メール確認ページ（verify_email_page）に「最初からやり直す」ボタンを追加し、サインアウトしてwelcome_pageへ戻れるようにした。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #140

## 変更内容
- `verify_email_page.dart` の下部に「最初からやり直す」`TextButton` を追加
- ボタン押下時にサインアウト（`authProvider.notifier.signOut()`）してから `/welcome` へ遷移
- `go_router` の `go_router.dart` をインポートに追加

## スクリーンショット
（該当なし）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）