### PR TITLE
[Search] 検索結果画面にページネーション機能を追加

### DIFF
--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -48,6 +48,7 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
               .toList(),
           page: response.page ?? page,
           nbPages: response.nbPages ?? 1,
+          nbHits: response.nbHits ?? hits.length,
         );
       }
     } catch (error) {

--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -5,6 +5,7 @@ import 'package:algoliasearch/algoliasearch.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/search/data/datasources/search_data_source.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
+import 'package:kenryo_tankyu/features/search/domain/models/search_result.dart';
 import 'package:kenryo_tankyu/features/search/domain/repositories/search_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -16,7 +17,7 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
   final SearchDataSource _dataSource;
 
   @override
-  Future<List<Searched>?> search({
+  Future<SearchResult?> search({
     required Search params,
     int page = 0,
     int? hitsPerPage,
@@ -41,9 +42,13 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
       if (hits.isEmpty) {
         return null;
       } else {
-        return hits.map((object) {
-          return Searched.fromAlgolia(object, false);
-        }).toList();
+        return SearchResult(
+          hits: hits
+              .map((object) => Searched.fromAlgolia(object, false))
+              .toList(),
+          page: response.page ?? page,
+          nbPages: response.nbPages ?? 1,
+        );
       }
     } catch (error) {
       throw mapException(error);

--- a/lib/features/search/domain/models/search_result.dart
+++ b/lib/features/search/domain/models/search_result.dart
@@ -9,6 +9,7 @@ abstract class SearchResult with _$SearchResult {
     required List<Searched> hits,
     required int page,
     required int nbPages,
+    required int nbHits,
   }) = _SearchResult;
 
   const SearchResult._();

--- a/lib/features/search/domain/models/search_result.dart
+++ b/lib/features/search/domain/models/search_result.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+
+part 'search_result.freezed.dart';
+
+@freezed
+abstract class SearchResult with _$SearchResult {
+  const factory SearchResult({
+    required List<Searched> hits,
+    required int page,
+    required int nbPages,
+  }) = _SearchResult;
+
+  const SearchResult._();
+
+  bool get isLastPage => page >= nbPages - 1;
+}

--- a/lib/features/search/domain/models/search_result.freezed.dart
+++ b/lib/features/search/domain/models/search_result.freezed.dart
@@ -17,6 +17,7 @@ mixin _$SearchResult {
   List<Searched> get hits;
   int get page;
   int get nbPages;
+  int get nbHits;
 
   /// Create a copy of SearchResult
   /// with the given fields replaced by the non-null parameter values.
@@ -33,16 +34,17 @@ mixin _$SearchResult {
             other is SearchResult &&
             const DeepCollectionEquality().equals(other.hits, hits) &&
             (identical(other.page, page) || other.page == page) &&
-            (identical(other.nbPages, nbPages) || other.nbPages == nbPages));
+            (identical(other.nbPages, nbPages) || other.nbPages == nbPages) &&
+            (identical(other.nbHits, nbHits) || other.nbHits == nbHits));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(hits), page, nbPages);
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(hits), page, nbPages, nbHits);
 
   @override
   String toString() {
-    return 'SearchResult(hits: $hits, page: $page, nbPages: $nbPages)';
+    return 'SearchResult(hits: $hits, page: $page, nbPages: $nbPages, nbHits: $nbHits)';
   }
 }
 
@@ -52,7 +54,7 @@ abstract mixin class $SearchResultCopyWith<$Res> {
           SearchResult value, $Res Function(SearchResult) _then) =
       _$SearchResultCopyWithImpl;
   @useResult
-  $Res call({List<Searched> hits, int page, int nbPages});
+  $Res call({List<Searched> hits, int page, int nbPages, int nbHits});
 }
 
 /// @nodoc
@@ -70,6 +72,7 @@ class _$SearchResultCopyWithImpl<$Res> implements $SearchResultCopyWith<$Res> {
     Object? hits = null,
     Object? page = null,
     Object? nbPages = null,
+    Object? nbHits = null,
   }) {
     return _then(_self.copyWith(
       hits: null == hits
@@ -83,6 +86,10 @@ class _$SearchResultCopyWithImpl<$Res> implements $SearchResultCopyWith<$Res> {
       nbPages: null == nbPages
           ? _self.nbPages
           : nbPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      nbHits: null == nbHits
+          ? _self.nbHits
+          : nbHits // ignore: cast_nullable_to_non_nullable
               as int,
     ));
   }
@@ -181,13 +188,14 @@ extension SearchResultPatterns on SearchResult {
 
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(List<Searched> hits, int page, int nbPages)? $default, {
+    TResult Function(List<Searched> hits, int page, int nbPages, int nbHits)?
+        $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _SearchResult() when $default != null:
-        return $default(_that.hits, _that.page, _that.nbPages);
+        return $default(_that.hits, _that.page, _that.nbPages, _that.nbHits);
       case _:
         return orElse();
     }
@@ -208,12 +216,13 @@ extension SearchResultPatterns on SearchResult {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(List<Searched> hits, int page, int nbPages) $default,
+    TResult Function(List<Searched> hits, int page, int nbPages, int nbHits)
+        $default,
   ) {
     final _that = this;
     switch (_that) {
       case _SearchResult():
-        return $default(_that.hits, _that.page, _that.nbPages);
+        return $default(_that.hits, _that.page, _that.nbPages, _that.nbHits);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -233,12 +242,13 @@ extension SearchResultPatterns on SearchResult {
 
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(List<Searched> hits, int page, int nbPages)? $default,
+    TResult? Function(List<Searched> hits, int page, int nbPages, int nbHits)?
+        $default,
   ) {
     final _that = this;
     switch (_that) {
       case _SearchResult() when $default != null:
-        return $default(_that.hits, _that.page, _that.nbPages);
+        return $default(_that.hits, _that.page, _that.nbPages, _that.nbHits);
       case _:
         return null;
     }
@@ -251,7 +261,8 @@ class _SearchResult extends SearchResult {
   const _SearchResult(
       {required final List<Searched> hits,
       required this.page,
-      required this.nbPages})
+      required this.nbPages,
+      required this.nbHits})
       : _hits = hits,
         super._();
 
@@ -267,6 +278,8 @@ class _SearchResult extends SearchResult {
   final int page;
   @override
   final int nbPages;
+  @override
+  final int nbHits;
 
   /// Create a copy of SearchResult
   /// with the given fields replaced by the non-null parameter values.
@@ -283,16 +296,17 @@ class _SearchResult extends SearchResult {
             other is _SearchResult &&
             const DeepCollectionEquality().equals(other._hits, _hits) &&
             (identical(other.page, page) || other.page == page) &&
-            (identical(other.nbPages, nbPages) || other.nbPages == nbPages));
+            (identical(other.nbPages, nbPages) || other.nbPages == nbPages) &&
+            (identical(other.nbHits, nbHits) || other.nbHits == nbHits));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(_hits), page, nbPages);
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(_hits), page, nbPages, nbHits);
 
   @override
   String toString() {
-    return 'SearchResult(hits: $hits, page: $page, nbPages: $nbPages)';
+    return 'SearchResult(hits: $hits, page: $page, nbPages: $nbPages, nbHits: $nbHits)';
   }
 }
 
@@ -304,7 +318,7 @@ abstract mixin class _$SearchResultCopyWith<$Res>
       __$SearchResultCopyWithImpl;
   @override
   @useResult
-  $Res call({List<Searched> hits, int page, int nbPages});
+  $Res call({List<Searched> hits, int page, int nbPages, int nbHits});
 }
 
 /// @nodoc
@@ -323,6 +337,7 @@ class __$SearchResultCopyWithImpl<$Res>
     Object? hits = null,
     Object? page = null,
     Object? nbPages = null,
+    Object? nbHits = null,
   }) {
     return _then(_SearchResult(
       hits: null == hits
@@ -336,6 +351,10 @@ class __$SearchResultCopyWithImpl<$Res>
       nbPages: null == nbPages
           ? _self.nbPages
           : nbPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      nbHits: null == nbHits
+          ? _self.nbHits
+          : nbHits // ignore: cast_nullable_to_non_nullable
               as int,
     ));
   }

--- a/lib/features/search/domain/models/search_result.freezed.dart
+++ b/lib/features/search/domain/models/search_result.freezed.dart
@@ -1,0 +1,344 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'search_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SearchResult {
+  List<Searched> get hits;
+  int get page;
+  int get nbPages;
+
+  /// Create a copy of SearchResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $SearchResultCopyWith<SearchResult> get copyWith =>
+      _$SearchResultCopyWithImpl<SearchResult>(
+          this as SearchResult, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is SearchResult &&
+            const DeepCollectionEquality().equals(other.hits, hits) &&
+            (identical(other.page, page) || other.page == page) &&
+            (identical(other.nbPages, nbPages) || other.nbPages == nbPages));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(hits), page, nbPages);
+
+  @override
+  String toString() {
+    return 'SearchResult(hits: $hits, page: $page, nbPages: $nbPages)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $SearchResultCopyWith<$Res> {
+  factory $SearchResultCopyWith(
+          SearchResult value, $Res Function(SearchResult) _then) =
+      _$SearchResultCopyWithImpl;
+  @useResult
+  $Res call({List<Searched> hits, int page, int nbPages});
+}
+
+/// @nodoc
+class _$SearchResultCopyWithImpl<$Res> implements $SearchResultCopyWith<$Res> {
+  _$SearchResultCopyWithImpl(this._self, this._then);
+
+  final SearchResult _self;
+  final $Res Function(SearchResult) _then;
+
+  /// Create a copy of SearchResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hits = null,
+    Object? page = null,
+    Object? nbPages = null,
+  }) {
+    return _then(_self.copyWith(
+      hits: null == hits
+          ? _self.hits
+          : hits // ignore: cast_nullable_to_non_nullable
+              as List<Searched>,
+      page: null == page
+          ? _self.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as int,
+      nbPages: null == nbPages
+          ? _self.nbPages
+          : nbPages // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [SearchResult].
+extension SearchResultPatterns on SearchResult {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_SearchResult value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SearchResult() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_SearchResult value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SearchResult():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_SearchResult value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SearchResult() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<Searched> hits, int page, int nbPages)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SearchResult() when $default != null:
+        return $default(_that.hits, _that.page, _that.nbPages);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<Searched> hits, int page, int nbPages) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SearchResult():
+        return $default(_that.hits, _that.page, _that.nbPages);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(List<Searched> hits, int page, int nbPages)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SearchResult() when $default != null:
+        return $default(_that.hits, _that.page, _that.nbPages);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _SearchResult extends SearchResult {
+  const _SearchResult(
+      {required final List<Searched> hits,
+      required this.page,
+      required this.nbPages})
+      : _hits = hits,
+        super._();
+
+  final List<Searched> _hits;
+  @override
+  List<Searched> get hits {
+    if (_hits is EqualUnmodifiableListView) return _hits;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_hits);
+  }
+
+  @override
+  final int page;
+  @override
+  final int nbPages;
+
+  /// Create a copy of SearchResult
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$SearchResultCopyWith<_SearchResult> get copyWith =>
+      __$SearchResultCopyWithImpl<_SearchResult>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _SearchResult &&
+            const DeepCollectionEquality().equals(other._hits, _hits) &&
+            (identical(other.page, page) || other.page == page) &&
+            (identical(other.nbPages, nbPages) || other.nbPages == nbPages));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_hits), page, nbPages);
+
+  @override
+  String toString() {
+    return 'SearchResult(hits: $hits, page: $page, nbPages: $nbPages)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$SearchResultCopyWith<$Res>
+    implements $SearchResultCopyWith<$Res> {
+  factory _$SearchResultCopyWith(
+          _SearchResult value, $Res Function(_SearchResult) _then) =
+      __$SearchResultCopyWithImpl;
+  @override
+  @useResult
+  $Res call({List<Searched> hits, int page, int nbPages});
+}
+
+/// @nodoc
+class __$SearchResultCopyWithImpl<$Res>
+    implements _$SearchResultCopyWith<$Res> {
+  __$SearchResultCopyWithImpl(this._self, this._then);
+
+  final _SearchResult _self;
+  final $Res Function(_SearchResult) _then;
+
+  /// Create a copy of SearchResult
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? hits = null,
+    Object? page = null,
+    Object? nbPages = null,
+  }) {
+    return _then(_SearchResult(
+      hits: null == hits
+          ? _self._hits
+          : hits // ignore: cast_nullable_to_non_nullable
+              as List<Searched>,
+      page: null == page
+          ? _self.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as int,
+      nbPages: null == nbPages
+          ? _self.nbPages
+          : nbPages // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/features/search/domain/repositories/search_repository.dart
+++ b/lib/features/search/domain/repositories/search_repository.dart
@@ -1,8 +1,9 @@
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
+import 'package:kenryo_tankyu/features/search/domain/models/search_result.dart';
 
 abstract class SearchRepository {
-  Future<List<Searched>?> search({
+  Future<SearchResult?> search({
     required Search params,
     int page = 0,
     int? hitsPerPage,

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -13,6 +13,26 @@ import 'package:kenryo_tankyu/features/search/presentation/providers/search_hist
 
 final forceRefreshProvider = StateProvider.autoDispose<bool>((ref) => false);
 
+class SearchResultCacheNotifier extends Notifier<Map<int, SearchResult>> {
+  @override
+  Map<int, SearchResult> build() {
+    ref.listen(searchProvider, (previous, next) {
+      state = {};
+    });
+    return {};
+  }
+
+  SearchResult? get(int page) => state[page];
+
+  void set(int page, SearchResult result) {
+    state = {...state, page: result};
+  }
+}
+
+final searchResultCacheProvider = NotifierProvider.autoDispose<
+    SearchResultCacheNotifier,
+    Map<int, SearchResult>>(SearchResultCacheNotifier.new);
+
 class SearchPageNotifier extends Notifier<int> {
   @override
   int build() {
@@ -41,6 +61,13 @@ final algoliaSearchProvider =
       ref.read(searchProvider); //ref.readにすると、watchと違って値が変更されたときに再ビルドされない！
 
   final page = ref.watch(searchPageProvider);
+  final cache = ref.watch(searchResultCacheProvider.notifier);
+
+  final cached = cache.get(page);
+  if (cached != null) {
+    return cached;
+  }
+
   final repository = ref.watch(searchRepositoryProvider);
   final historyRepository = ref.watch(searchHistoryRepositoryProvider);
 
@@ -54,6 +81,10 @@ final algoliaSearchProvider =
 
   if (result == null && page > 0) {
     return SearchResult(hits: [], page: page, nbPages: page);
+  }
+
+  if (result != null) {
+    cache.set(page, result);
   }
 
   return result;

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -75,14 +75,12 @@ final algoliaSearchProvider =
 
   if (result != null && page == 0) {
     // Save history side effect (first page only)
-    // 続きがある場合は21を保存し「20件+」表示のセンチネルとして使う
-    final hitsCount = result.isLastPage ? result.hits.length : 21;
     await historyRepository.insertHistory(
-        search.copyWith(savedAt: DateTime.now(), numberOfHits: hitsCount));
+        search.copyWith(savedAt: DateTime.now(), numberOfHits: result.nbHits));
   }
 
   if (result == null && page > 0) {
-    return SearchResult(hits: [], page: page, nbPages: page);
+    return SearchResult(hits: [], page: page, nbPages: page, nbHits: 0);
   }
 
   if (result != null) {

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -75,8 +75,10 @@ final algoliaSearchProvider =
 
   if (result != null && page == 0) {
     // Save history side effect (first page only)
-    await historyRepository.insertHistory(search.copyWith(
-        savedAt: DateTime.now(), numberOfHits: result.hits.length));
+    // 続きがある場合は21を保存し「20件+」表示のセンチネルとして使う
+    final hitsCount = result.isLastPage ? result.hits.length : 21;
+    await historyRepository.insertHistory(
+        search.copyWith(savedAt: DateTime.now(), numberOfHits: hitsCount));
   }
 
   if (result == null && page > 0) {

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -12,6 +12,8 @@ import 'package:kenryo_tankyu/features/search/presentation/providers/search_hist
 
 final forceRefreshProvider = StateProvider.autoDispose<bool>((ref) => false);
 
+final searchPageProvider = StateProvider.autoDispose<int>((ref) => 0);
+
 final algoliaSearchProvider =
     FutureProvider.autoDispose<List<Searched>?>((ref) async {
   final isConnected = ref.watch(isConnectedProvider);
@@ -22,13 +24,14 @@ final algoliaSearchProvider =
   final search =
       ref.read(searchProvider); //ref.readにすると、watchと違って値が変更されたときに再ビルドされない！
 
+  final page = ref.watch(searchPageProvider);
   final repository = ref.watch(searchRepositoryProvider);
   final historyRepository = ref.watch(searchHistoryRepositoryProvider);
 
-  final result = await repository.search(params: search);
+  final result = await repository.search(params: search, page: page);
 
-  if (result != null) {
-    // Save history side effect
+  if (result != null && page == 0) {
+    // Save history side effect (first page only)
     await historyRepository.insertHistory(
         search.copyWith(savedAt: DateTime.now(), numberOfHits: result.length));
   }

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -12,7 +12,22 @@ import 'package:kenryo_tankyu/features/search/presentation/providers/search_hist
 
 final forceRefreshProvider = StateProvider.autoDispose<bool>((ref) => false);
 
-final searchPageProvider = StateProvider.autoDispose<int>((ref) => 0);
+class SearchPageNotifier extends Notifier<int> {
+  @override
+  int build() {
+    ref.listen(searchProvider, (previous, next) {
+      state = 0;
+    });
+    return 0;
+  }
+
+  void setPage(int page) => state = page;
+}
+
+final searchPageProvider =
+    NotifierProvider.autoDispose<SearchPageNotifier, int>(() {
+  return SearchPageNotifier();
+});
 
 final algoliaSearchProvider =
     FutureProvider.autoDispose<List<Searched>?>((ref) async {
@@ -34,6 +49,10 @@ final algoliaSearchProvider =
     // Save history side effect (first page only)
     await historyRepository.insertHistory(
         search.copyWith(savedAt: DateTime.now(), numberOfHits: result.length));
+  }
+
+  if (result == null && page > 0) {
+    return [];
   }
 
   return result;

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:kenryo_tankyu/core/constants/work/search_value.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/search/data/repositories/search_repository_impl.dart';
+import 'package:kenryo_tankyu/features/search/domain/models/search_result.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:kenryo_tankyu/core/connectivity/connectivity_provider.dart';
@@ -30,7 +31,7 @@ final searchPageProvider =
 });
 
 final algoliaSearchProvider =
-    FutureProvider.autoDispose<List<Searched>?>((ref) async {
+    FutureProvider.autoDispose<SearchResult?>((ref) async {
   final isConnected = ref.watch(isConnectedProvider);
   if (!isConnected) {
     throw const NetworkFailure();
@@ -47,12 +48,12 @@ final algoliaSearchProvider =
 
   if (result != null && page == 0) {
     // Save history side effect (first page only)
-    await historyRepository.insertHistory(
-        search.copyWith(savedAt: DateTime.now(), numberOfHits: result.length));
+    await historyRepository.insertHistory(search.copyWith(
+        savedAt: DateTime.now(), numberOfHits: result.hits.length));
   }
 
   if (result == null && page > 0) {
-    return [];
+    return SearchResult(hits: [], page: page, nbPages: page);
   }
 
   return result;
@@ -66,7 +67,7 @@ final sortedListProvider =
 class SortedListNotifier extends Notifier<List<Searched>> {
   @override
   List<Searched> build() {
-    final data = ref.watch(algoliaSearchProvider).asData?.value ?? [];
+    final data = ref.watch(algoliaSearchProvider).asData?.value?.hits ?? [];
     return data;
   }
 

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -71,6 +71,7 @@ class ResultListPage extends ConsumerWidget {
                         ));
                       } else {
                         final currentPage = ref.watch(searchPageProvider);
+                        final hits = data.hits;
                         return Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -78,13 +79,11 @@ class ResultListPage extends ConsumerWidget {
                               padding: const EdgeInsets.only(
                                   left: 8.0, top: 4.0, bottom: 4.0),
                               child: Text(
-                                data.isEmpty
+                                hits.isEmpty
                                     ? '該当するデータはありません'
-                                    : data.length == 20
-                                        ? '${currentPage * 20 + 1}〜${currentPage * 20 + 20}件目を表示中'
-                                        : currentPage == 0
-                                            ? '${data.length}件ヒットしました'
-                                            : '${currentPage * 20 + 1}〜${currentPage * 20 + data.length}件目を表示中',
+                                    : currentPage == 0
+                                        ? '${hits.length}件ヒットしました'
+                                        : '${currentPage * 20 + 1}〜${currentPage * 20 + hits.length}件目を表示中',
                                 style: const TextStyle(fontSize: 16),
                               ),
                             ),
@@ -113,7 +112,7 @@ class ResultListPage extends ConsumerWidget {
                                   Text('${currentPage + 1}ページ目'),
                                   TextButton.icon(
                                     onPressed: asyncValue.isLoading ||
-                                            data.length < 20
+                                            data.isLastPage
                                         ? null
                                         : () {
                                             ref

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -70,6 +70,7 @@ class ResultListPage extends ConsumerWidget {
                           ],
                         ));
                       } else {
+                        final currentPage = ref.watch(searchPageProvider);
                         return Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -78,12 +79,52 @@ class ResultListPage extends ConsumerWidget {
                                   left: 8.0, top: 4.0, bottom: 4.0),
                               child: Text(
                                 data.length == 20
-                                    ? '20件以上ヒットしました'
-                                    : '${data.length.toString()}件ヒットしました',
+                                    ? '${currentPage * 20 + 1}〜${currentPage * 20 + 20}件目を表示中'
+                                    : currentPage == 0
+                                        ? '${data.length}件ヒットしました'
+                                        : '${currentPage * 20 + 1}〜${currentPage * 20 + data.length}件目を表示中',
                                 style: const TextStyle(fontSize: 16),
                               ),
                             ),
                             ResultList(data: sortedList),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 8.0),
+                              child: Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  TextButton.icon(
+                                    onPressed: currentPage == 0
+                                        ? null
+                                        : () {
+                                            ref
+                                                .read(
+                                                    searchPageProvider.notifier)
+                                                .state = currentPage - 1;
+                                          },
+                                    icon: const Icon(Icons.arrow_back_ios,
+                                        size: 16),
+                                    label: const Text('前のページへ'),
+                                  ),
+                                  Text('${currentPage + 1}ページ目'),
+                                  TextButton.icon(
+                                    onPressed: data.length < 20
+                                        ? null
+                                        : () {
+                                            ref
+                                                .read(
+                                                    searchPageProvider.notifier)
+                                                .state = currentPage + 1;
+                                          },
+                                    icon: const Icon(Icons.arrow_forward_ios,
+                                        size: 16),
+                                    label: const Text('次のページへ'),
+                                    iconAlignment: IconAlignment.end,
+                                  ),
+                                ],
+                              ),
+                            ),
                           ],
                         );
                       }

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -81,7 +81,7 @@ class ResultListPage extends ConsumerWidget {
                               child: Text(
                                 hits.isEmpty
                                     ? '該当するデータはありません'
-                                    : currentPage == 0
+                                    : data.isLastPage && currentPage == 0
                                         ? '${hits.length}件ヒットしました'
                                         : '${currentPage * 20 + 1}〜${currentPage * 20 + hits.length}件目を表示中',
                                 style: const TextStyle(fontSize: 16),

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -78,11 +78,13 @@ class ResultListPage extends ConsumerWidget {
                               padding: const EdgeInsets.only(
                                   left: 8.0, top: 4.0, bottom: 4.0),
                               child: Text(
-                                data.length == 20
-                                    ? '${currentPage * 20 + 1}〜${currentPage * 20 + 20}件目を表示中'
-                                    : currentPage == 0
-                                        ? '${data.length}件ヒットしました'
-                                        : '${currentPage * 20 + 1}〜${currentPage * 20 + data.length}件目を表示中',
+                                data.isEmpty
+                                    ? '該当するデータはありません'
+                                    : data.length == 20
+                                        ? '${currentPage * 20 + 1}〜${currentPage * 20 + 20}件目を表示中'
+                                        : currentPage == 0
+                                            ? '${data.length}件ヒットしました'
+                                            : '${currentPage * 20 + 1}〜${currentPage * 20 + data.length}件目を表示中',
                                 style: const TextStyle(fontSize: 16),
                               ),
                             ),
@@ -95,13 +97,14 @@ class ResultListPage extends ConsumerWidget {
                                     MainAxisAlignment.spaceBetween,
                                 children: [
                                   TextButton.icon(
-                                    onPressed: currentPage == 0
+                                    onPressed: asyncValue.isLoading ||
+                                            currentPage == 0
                                         ? null
                                         : () {
                                             ref
                                                 .read(
                                                     searchPageProvider.notifier)
-                                                .state = currentPage - 1;
+                                                .setPage(currentPage - 1);
                                           },
                                     icon: const Icon(Icons.arrow_back_ios,
                                         size: 16),
@@ -109,13 +112,14 @@ class ResultListPage extends ConsumerWidget {
                                   ),
                                   Text('${currentPage + 1}ページ目'),
                                   TextButton.icon(
-                                    onPressed: data.length < 20
+                                    onPressed: asyncValue.isLoading ||
+                                            data.length < 20
                                         ? null
                                         : () {
                                             ref
                                                 .read(
                                                     searchPageProvider.notifier)
-                                                .state = currentPage + 1;
+                                                .setPage(currentPage + 1);
                                           },
                                     icon: const Icon(Icons.arrow_forward_ios,
                                         size: 16),

--- a/lib/features/search/presentation/widgets/search_history_list.dart
+++ b/lib/features/search/presentation/widgets/search_history_list.dart
@@ -42,10 +42,7 @@ class SearchHistoryList extends ConsumerWidget {
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis),
                               ),
-                              Text(
-                                  search.numberOfHits > 20
-                                      ? '20件+'
-                                      : ' ${search.numberOfHits}件',
+                              Text(' ${search.numberOfHits}件',
                                   style: const TextStyle(fontSize: 12)),
                             ],
                           ),

--- a/lib/features/search/presentation/widgets/search_history_list.dart
+++ b/lib/features/search/presentation/widgets/search_history_list.dart
@@ -43,7 +43,7 @@ class SearchHistoryList extends ConsumerWidget {
                                     overflow: TextOverflow.ellipsis),
                               ),
                               Text(
-                                  search.numberOfHits == 20
+                                  search.numberOfHits > 20
                                       ? '20件+'
                                       : ' ${search.numberOfHits}件',
                                   style: const TextStyle(fontSize: 12)),


### PR DESCRIPTION
## 概要
検索結果が20件を超える場合に次のページを表示できなかった問題を解消し、ページネーション機能を実装する。

## 種別
- [x] 機能追加

## 関連Issue
Closes #144

## 変更内容
- `algolia_provider.dart`: 現在のページ番号を管理する `searchPageProvider`（`StateProvider<int>`）を追加
- `algoliaSearchProvider` が `searchPageProvider` を watch し、Algolia の `page` パラメータへ渡すよう修正
  - 検索履歴への保存は1ページ目（page=0）のみに限定
- `result_list_page.dart`: リスト下部にページネーションバーを追加
  - 「前のページへ」ボタン（1ページ目では非活性）
  - 現在のページ番号表示（○ページ目）
  - 「次のページへ」ボタン（取得件数が20件未満の最終ページでは非活性）
  - 件数表示を「○〜○件目を表示中」形式に対応

## スクリーンショット
（省略）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）