### PR TITLE
[Supabase] セッション②: お気に入りをSupabaseに移行・検索結果のisFavorite修正

### DIFF
--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -31,6 +31,8 @@ class AuthNotifier extends _$AuthNotifier {
             unawaited(
               ref.read(favoriteIdsCacheProvider.notifier).initialize(user.uid),
             );
+          } else {
+            ref.invalidate(favoriteIdsCacheProvider);
           }
         });
       },

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
 import "package:kenryo_tankyu/core/constants/feature/user_value.dart";
 import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_repository_provider.dart';
@@ -7,6 +8,7 @@ import 'package:kenryo_tankyu/features/notification/data/datasources/notificatio
 import 'package:kenryo_tankyu/features/search/data/datasources/search_history_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/searched_history_local_data_source.dart';
+import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'auth_provider.g.dart';
@@ -20,6 +22,19 @@ Stream<User?> authStateChanges(Ref ref) {
 class AuthNotifier extends _$AuthNotifier {
   @override
   Auth build() {
+    ref.listen<AsyncValue<User?>>(
+      authStateChangesProvider,
+      fireImmediately: true,
+      (_, next) {
+        next.whenData((user) {
+          if (user != null && user.emailVerified) {
+            unawaited(
+              ref.read(favoriteIdsCacheProvider.notifier).initialize(user.uid),
+            );
+          }
+        });
+      },
+    );
     return const Auth();
   }
 

--- a/lib/features/auth/presentation/providers/auth_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.g.dart
@@ -73,7 +73,7 @@ final class AuthNotifierProvider extends $NotifierProvider<AuthNotifier, Auth> {
   }
 }
 
-String _$authNotifierHash() => r'b439bf75bcba5861bb641403252949d3ff463b83';
+String _$authNotifierHash() => r'5ab80b5b37b741cb843c2f0269705277c6067e55';
 
 abstract class _$AuthNotifier extends $Notifier<Auth> {
   Auth build();

--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -49,7 +49,7 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
           hits: hits
               .map((object) => Searched.fromAlgolia(
                     object,
-                    favoriteIds.contains(int.parse(object.objectID)),
+                    favoriteIds.contains(int.tryParse(object.objectID) ?? -1),
                   ))
               .toList(),
           page: response.page ?? page,
@@ -92,7 +92,7 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
         final hits = resp.hits;
         results.addAll(hits.map((e) => Searched.fromAlgolia(
               e,
-              favoriteIds.contains(int.parse(e.objectID)),
+              favoriteIds.contains(int.tryParse(e.objectID) ?? -1),
             )));
       }
     } catch (e) {

--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -7,14 +7,16 @@ import 'package:kenryo_tankyu/features/search/data/datasources/search_data_sourc
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search_result.dart';
 import 'package:kenryo_tankyu/features/search/domain/repositories/search_repository.dart';
+import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'search_repository_impl.g.dart';
 
 class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
-  SearchRepositoryImpl(this._dataSource);
+  SearchRepositoryImpl(this._dataSource, this._getFavoriteIds);
 
   final SearchDataSource _dataSource;
+  final Set<int> Function() _getFavoriteIds;
 
   @override
   Future<SearchResult?> search({
@@ -42,9 +44,13 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
       if (hits.isEmpty) {
         return null;
       } else {
+        final favoriteIds = _getFavoriteIds();
         return SearchResult(
           hits: hits
-              .map((object) => Searched.fromAlgolia(object, false))
+              .map((object) => Searched.fromAlgolia(
+                    object,
+                    favoriteIds.contains(int.parse(object.objectID)),
+                  ))
               .toList(),
           page: response.page ?? page,
           nbPages: response.nbPages ?? 1,
@@ -72,6 +78,7 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
     }
 
     try {
+      final favoriteIds = _getFavoriteIds();
       for (final page in pages) {
         final query = SearchForHits(
           indexName: 'firestore',
@@ -83,7 +90,10 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
             .searchIndex(request: query)
             .timeout(const Duration(seconds: 5));
         final hits = resp.hits;
-        results.addAll(hits.map((e) => Searched.fromAlgolia(e, false)));
+        results.addAll(hits.map((e) => Searched.fromAlgolia(
+              e,
+              favoriteIds.contains(int.parse(e.objectID)),
+            )));
       }
     } catch (e) {
       throw mapException(e);
@@ -114,5 +124,8 @@ class SearchRepositoryImpl with ErrorMapper implements SearchRepository {
 @riverpod
 SearchRepository searchRepository(Ref ref) {
   final dataSource = ref.watch(searchDataSourceProvider);
-  return SearchRepositoryImpl(dataSource);
+  return SearchRepositoryImpl(
+    dataSource,
+    () => ref.read(favoriteIdsCacheProvider),
+  );
 }

--- a/lib/features/search/data/repositories/search_repository_impl.g.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.g.dart
@@ -49,4 +49,4 @@ final class SearchRepositoryProvider extends $FunctionalProvider<
   }
 }
 
-String _$searchRepositoryHash() => r'bc7b557899e398232e22d6d40932978fe0eb2266';
+String _$searchRepositoryHash() => r'b8b084724253ff80c1ff6cb607664b54c16360ae';

--- a/lib/features/user_archive/data/datasources/favorites_remote_data_source.dart
+++ b/lib/features/user_archive/data/datasources/favorites_remote_data_source.dart
@@ -1,0 +1,49 @@
+import 'package:kenryo_tankyu/core/providers/supabase_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'favorites_remote_data_source.g.dart';
+
+@Riverpod(keepAlive: true)
+FavoritesRemoteDataSource favoritesRemoteDataSource(Ref ref) {
+  return FavoritesRemoteDataSource(ref.watch(supabaseClientProvider));
+}
+
+class FavoritesRemoteDataSource {
+  FavoritesRemoteDataSource(this._client);
+
+  final SupabaseClient _client;
+
+  Future<Set<int>> getFavoriteIds(String userId) async {
+    final rows = await _client
+        .from('favorites')
+        .select('document_id')
+        .eq('user_id', userId);
+    return rows.map<int>((r) => r['document_id'] as int).toSet();
+  }
+
+  Future<void> addFavorite(String userId, int documentId) async {
+    await _client.from('favorites').upsert({
+      'user_id': userId,
+      'document_id': documentId,
+    });
+  }
+
+  Future<void> removeFavorite(String userId, int documentId) async {
+    await _client
+        .from('favorites')
+        .delete()
+        .eq('user_id', userId)
+        .eq('document_id', documentId);
+  }
+
+  Future<bool> isFavorite(String userId, int documentId) async {
+    final row = await _client
+        .from('favorites')
+        .select('document_id')
+        .eq('user_id', userId)
+        .eq('document_id', documentId)
+        .maybeSingle();
+    return row != null;
+  }
+}

--- a/lib/features/user_archive/data/datasources/favorites_remote_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/favorites_remote_data_source.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'favorites_remote_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(favoritesRemoteDataSource)
+const favoritesRemoteDataSourceProvider = FavoritesRemoteDataSourceProvider._();
+
+final class FavoritesRemoteDataSourceProvider extends $FunctionalProvider<
+    FavoritesRemoteDataSource,
+    FavoritesRemoteDataSource,
+    FavoritesRemoteDataSource> with $Provider<FavoritesRemoteDataSource> {
+  const FavoritesRemoteDataSourceProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'favoritesRemoteDataSourceProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$favoritesRemoteDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<FavoritesRemoteDataSource> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  FavoritesRemoteDataSource create(Ref ref) {
+    return favoritesRemoteDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(FavoritesRemoteDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<FavoritesRemoteDataSource>(value),
+    );
+  }
+}
+
+String _$favoritesRemoteDataSourceHash() =>
+    r'2ae6a14e1ee6ff971412884f9b4c9eef38b16b6b';

--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -44,6 +44,9 @@ class UserArchiveRepositoryImpl
     try {
       final favoriteIds = await _favoritesDataSource.getFavoriteIds(userId);
       if (favoriteIds.isEmpty) return null;
+      // セッション③完了まで SQLite の閲覧履歴を取得源とする。
+      // そのため新デバイスや履歴削除後はお気に入り一覧に表示されない制約がある。
+      // browsing_history の Supabase 移行後に Supabase から直接取得する実装に切り替える。
       final allHistory = await _historyDataSource.getAllHistory();
       if (allHistory == null) return null;
       final favorites = allHistory

--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/error/error_mapper.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/favorites_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/recommended_works_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/searched_history_local_data_source.dart';
@@ -13,12 +15,14 @@ class UserArchiveRepositoryImpl
     with ErrorMapper
     implements UserArchiveRepository {
   final SearchedHistoryLocalDataSource _historyDataSource;
+  final FavoritesRemoteDataSource _favoritesDataSource;
   final PdfLocalDataSource _pdfDataSource;
   final RecommendedWorksLocalDataSource _recommendedDataSource;
   final UserArchiveRemoteDataSource _remoteDataSource;
 
   UserArchiveRepositoryImpl(
     this._historyDataSource,
+    this._favoritesDataSource,
     this._pdfDataSource,
     this._recommendedDataSource,
     this._remoteDataSource,
@@ -35,8 +39,18 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<List<Searched>?> getFavoriteHistory() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return null;
     try {
-      return await _historyDataSource.getFavoriteHistory();
+      final favoriteIds = await _favoritesDataSource.getFavoriteIds(userId);
+      if (favoriteIds.isEmpty) return null;
+      final allHistory = await _historyDataSource.getAllHistory();
+      if (allHistory == null) return null;
+      final favorites = allHistory
+          .where((h) => favoriteIds.contains(h.documentID))
+          .map((h) => h.copyWith(isFavorite: true))
+          .toList();
+      return favorites.isEmpty ? null : favorites;
     } catch (e) {
       throw mapException(e);
     }
@@ -107,24 +121,32 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<void> changeFavoriteState(int documentID, bool nextIsFavorite) async {
-    // isFavorite は楽観的に SQLite へ即時保存。
-    // likes カウントは Firestore の更新が確認できた後にのみ SQLite を更新する。
-    // Firestore 失敗時のみ isFavorite をロールバックして不整合を防ぐ。
-    // updateLikes（SQLite）の失敗時はロールバック不要（Firestore は既に成功済み）。
-    final previousIsFavorite = !nextIsFavorite;
-    await _historyDataSource.changeFavoriteState(documentID, nextIsFavorite);
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) throw mapException(Exception('ログインしていません'));
+
+    // Supabase favorites テーブルを更新（主ストア）
+    if (nextIsFavorite) {
+      await _favoritesDataSource.addFavorite(userId, documentID);
+    } else {
+      await _favoritesDataSource.removeFavorite(userId, documentID);
+    }
+
+    // Firestore の likes カウントを更新（失敗時は Supabase をロールバック）
     try {
       await updateRemoteLikes(documentID, nextIsFavorite);
     } catch (e) {
-      // Firestore 失敗: SQLite の isFavorite をロールバック
       try {
-        await _historyDataSource.changeFavoriteState(
-            documentID, previousIsFavorite);
-      } catch (_) {
-        // ロールバック自体が失敗した場合は無視
-      }
+        if (nextIsFavorite) {
+          await _favoritesDataSource.removeFavorite(userId, documentID);
+        } else {
+          await _favoritesDataSource.addFavorite(userId, documentID);
+        }
+      } catch (_) {}
       throw mapException(e);
     }
+
+    // SQLite の isFavorite も同期（セッション⑥で削除予定）
+    await _historyDataSource.changeFavoriteState(documentID, nextIsFavorite);
     await _historyDataSource.updateLikes(documentID, nextIsFavorite ? 1 : -1);
   }
 
@@ -141,8 +163,10 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<bool> getFavoriteState(int documentID) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return false;
     try {
-      return await _historyDataSource.getFavoriteState(documentID);
+      return await _favoritesDataSource.isFavorite(userId, documentID);
     } catch (e) {
       throw mapException(e);
     }
@@ -150,8 +174,13 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<List<int>?>? getSomeFavoriteState(List<int> documentIDs) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return null;
     try {
-      return await _historyDataSource.getSomeFavoriteState(documentIDs);
+      final favoriteIds = await _favoritesDataSource.getFavoriteIds(userId);
+      final result =
+          documentIDs.where((id) => favoriteIds.contains(id)).toList();
+      return result.isEmpty ? null : result;
     } catch (e) {
       throw mapException(e);
     }

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -5,6 +5,7 @@ import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/providers/searched_provider.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/favorites_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/recommended_works_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/searched_history_local_data_source.dart';
@@ -19,6 +20,7 @@ part 'user_archive_providers.g.dart';
 @riverpod
 UserArchiveRepository userArchiveRepository(Ref ref) {
   final historyDataSource = ref.watch(searchedHistoryLocalDataSourceProvider);
+  final favoritesDataSource = ref.watch(favoritesRemoteDataSourceProvider);
   final pdfDataSource = ref.watch(pdfLocalDataSourceProvider);
   final recommendedDataSource =
       ref.watch(recommendedWorksLocalDataSourceProvider);
@@ -26,10 +28,25 @@ UserArchiveRepository userArchiveRepository(Ref ref) {
 
   return UserArchiveRepositoryImpl(
     historyDataSource,
+    favoritesDataSource,
     pdfDataSource,
     recommendedDataSource,
     remoteDataSource,
   );
+}
+
+@Riverpod(keepAlive: true)
+class FavoriteIdsCache extends _$FavoriteIdsCache {
+  @override
+  Set<int> build() => {};
+
+  Future<void> initialize(String userId) async {
+    final dataSource = ref.read(favoritesRemoteDataSourceProvider);
+    state = await dataSource.getFavoriteIds(userId);
+  }
+
+  void add(int id) => state = {...state, id};
+  void remove(int id) => state = state.difference({id});
 }
 
 /// ボタン連打防止を管理するProvider
@@ -65,8 +82,14 @@ class UserIsFavoriteState extends _$UserIsFavoriteState {
     state = const AsyncLoading<bool>();
 
     state = await AsyncValue.guard(() async {
-      // Repository handles both local DB and remote Firestore updates
       await repository.changeFavoriteState(documentID, nextIsFavorite);
+
+      // インメモリキャッシュを即時更新
+      if (nextIsFavorite) {
+        ref.read(favoriteIdsCacheProvider.notifier).add(documentID);
+      } else {
+        ref.read(favoriteIdsCacheProvider.notifier).remove(documentID);
+      }
 
       // 関連するProviderを無効化
       ref.invalidate(searchedHistoryProvider);

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -42,7 +42,11 @@ class FavoriteIdsCache extends _$FavoriteIdsCache {
 
   Future<void> initialize(String userId) async {
     final dataSource = ref.read(favoritesRemoteDataSourceProvider);
-    state = await dataSource.getFavoriteIds(userId);
+    try {
+      state = await dataSource.getFavoriteIds(userId);
+    } catch (_) {
+      state = {};
+    }
   }
 
   void add(int id) => state = {...state, id};

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
@@ -51,7 +51,54 @@ final class UserArchiveRepositoryProvider extends $FunctionalProvider<
 }
 
 String _$userArchiveRepositoryHash() =>
-    r'c6db8d55d13a427585aad30fe5e7eb0f4dc33f40';
+    r'f843658a661f0d403b10a7a029dbfcca65e30650';
+
+@ProviderFor(FavoriteIdsCache)
+const favoriteIdsCacheProvider = FavoriteIdsCacheProvider._();
+
+final class FavoriteIdsCacheProvider
+    extends $NotifierProvider<FavoriteIdsCache, Set<int>> {
+  const FavoriteIdsCacheProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'favoriteIdsCacheProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$favoriteIdsCacheHash();
+
+  @$internal
+  @override
+  FavoriteIdsCache create() => FavoriteIdsCache();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<int>>(value),
+    );
+  }
+}
+
+String _$favoriteIdsCacheHash() => r'3cf55c7e5b5cf6e2fd26a951de32b2c8c7c450c3';
+
+abstract class _$FavoriteIdsCache extends $Notifier<Set<int>> {
+  Set<int> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<Set<int>, Set<int>>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<Set<int>, Set<int>>, Set<int>, Object?, Object?>;
+    element.handleValue(ref, created);
+  }
+}
 
 /// ボタン連打防止を管理するProvider
 
@@ -149,7 +196,7 @@ final class UserIsFavoriteStateProvider
 }
 
 String _$userIsFavoriteStateHash() =>
-    r'7b0ea0aa4cf8c32da25e818bfbac9396ca605636';
+    r'c478737a523ceebc50049715c72d38d5d0d00fc9';
 
 final class UserIsFavoriteStateFamily extends $Family
     with


### PR DESCRIPTION
## 概要
お気に入り機能のバックエンドを SQLite から Supabase に移行する。
また、検索結果一覧でハートアイコンが常に OFF になっていたバグを解消する。

## 種別
- [x] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
なし

## 変更内容

### 新規ファイル
- `FavoritesRemoteDataSource` を追加
  - Supabase `favorites` テーブルへの CRUD（`addFavorite` / `removeFavorite` / `isFavorite` / `getFavoriteIds`）

### 既存ファイルの変更
- `UserArchiveRepositoryImpl`
  - `getFavoriteHistory` / `changeFavoriteState` / `getFavoriteState` / `getSomeFavoriteState` を Supabase 版に差し替え
  - Firestore への likes インクリメント処理は現状維持
  - SQLite の `isFavorite` 列は引き続き同期（セッション⑥で削除予定）
- `user_archive_providers.dart`
  - `FavoriteIdsCache` Provider を追加（ログイン時に全件取得・`Set<int>` でメモリキャッシュ）
  - `UserIsFavoriteState.toggle()` でトグル後にキャッシュを即時更新
- `auth_provider.dart`
  - `AuthNotifier.build()` に `authStateChanges` のリスナーを追加
  - ログイン確定（emailVerified）時に `FavoriteIdsCache.initialize(uid)` を呼ぶ
- `search_repository_impl.dart`
  - `fromAlgolia(object, false)` → `FavoriteIdsCache` を参照するよう修正
  - 検索結果一覧・おすすめ作品の両方を修正

### 前提条件
- Supabase `favorites` テーブルが作成済みであること
- RLS が無効化されていること（`ALTER TABLE favorites DISABLE ROW LEVEL SECURITY;`）

## スクリーンショット
なし（UI 変更なし）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし（`flutter analyze`: No issues found）
- [ ] テストを追加または更新済み（必要な場合）