### PR TITLE
[Supabase] セッション③: 閲覧履歴をSupabaseに移行しlikes陳腐化チェックを実装

### DIFF
--- a/lib/features/auth/presentation/providers/auth_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.g.dart
@@ -73,7 +73,7 @@ final class AuthNotifierProvider extends $NotifierProvider<AuthNotifier, Auth> {
   }
 }
 
-String _$authNotifierHash() => r'5ab80b5b37b741cb843c2f0269705277c6067e55';
+String _$authNotifierHash() => r'8eda0dd8acfa00020900948de29acd646ccaa2e9';
 
 abstract class _$AuthNotifier extends $Notifier<Auth> {
   Auth build();

--- a/lib/features/research_work/domain/models/searched.dart
+++ b/lib/features/research_work/domain/models/searched.dart
@@ -89,4 +89,55 @@ abstract class Searched with _$Searched {
     json['savedAt'] = DateTime.now().toIso8601String();
     return json;
   }
+
+  /// Supabase の browsing_history テーブル用（user_id・viewed_at は含まない）
+  Map<String, dynamic> toSupabase() {
+    return {
+      'document_id': documentID,
+      'title': title,
+      'author': author,
+      'category1': const CategoryEnumConverter().toJson(category1),
+      'sub_category1': const SubCategoryEnumConverter().toJson(subCategory1),
+      'category2': const CategoryEnumConverter().toJson(category2),
+      'sub_category2': const SubCategoryEnumConverter().toJson(subCategory2),
+      'enter_year': const EnterYearEnumConverter().toJson(enterYear),
+      'event_name': const EventNameEnumConverter().toJson(eventName),
+      'course': const CourseEnumConverter().toJson(course),
+      'likes': likes,
+      'exists_slide': existsSlide,
+      'exists_report': existsReport,
+      'exists_thesis': existsThesis,
+      'exists_poster': existsPoster,
+    };
+  }
+
+  factory Searched.fromSupabase(Map<String, dynamic> row,
+      {bool isFavorite = false}) {
+    return Searched(
+      documentID: row['document_id'] as int,
+      isFavorite: isFavorite,
+      category1:
+          const CategoryEnumConverter().fromJson(row['category1'] as String),
+      subCategory1: const SubCategoryEnumConverter()
+          .fromJson(row['sub_category1'] as String),
+      category2:
+          const CategoryEnumConverter().fromJson(row['category2'] as String),
+      subCategory2: const SubCategoryEnumConverter()
+          .fromJson(row['sub_category2'] as String),
+      enterYear:
+          const EnterYearEnumConverter().fromJson(row['enter_year'] as int),
+      eventName:
+          const EventNameEnumConverter().fromJson(row['event_name'] as String),
+      course: const CourseEnumConverter().fromJson(row['course'] as String),
+      title: row['title'] as String,
+      author: row['author'] as String,
+      likes: row['likes'] as int,
+      existsSlide: row['exists_slide'] as bool,
+      existsReport: row['exists_report'] as bool,
+      existsThesis: row['exists_thesis'] as bool,
+      existsPoster: row['exists_poster'] as bool,
+      savedAt: DateTime.parse(row['viewed_at'] as String).toLocal(),
+      isCached: true,
+    );
+  }
 }

--- a/lib/features/research_work/presentation/providers/searched_provider.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:kenryo_tankyu/features/research_work/data/repositories/research_work_repository_impl.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
@@ -6,59 +8,101 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'searched_provider.g.dart';
 
-//全画面表示ボタンを表示するかしないかを管理するprovider
 final showFullScreenButtonProvider =
     StateProvider.autoDispose<bool>((ref) => true);
 
-//全画面か詳細画面かどうかを管理するprovider。IndexedStackに使用
 final isFullScreenProvider = StateProvider.autoDispose<bool>((ref) => false);
 
-//同じ探究作品を見ている最中なのかどうかを管理するprovider
-//このproviderを導入することによって、全画面に切り替えたときに不用意な再ビルドを防ぐ。
 final isSameScreenProvider = StateProvider.autoDispose<bool>((ref) => false);
 
 final forceReloadProvider = StateProvider.autoDispose<bool>((ref) => false);
 
 @riverpod
-Future<Searched> researchWork(Ref ref, int documentID) async {
-  final repository = ref.watch(researchWorkRepositoryProvider);
-  final archiveRepo = ref.watch(userArchiveRepositoryProvider);
-  final forceReload = ref.read(forceReloadProvider);
+class ResearchWork extends _$ResearchWork {
+  @override
+  Future<Searched> build(int documentID) async {
+    final repository = ref.watch(researchWorkRepositoryProvider);
+    final archiveRepo = ref.watch(userArchiveRepositoryProvider);
+    final forceReload = ref.read(forceReloadProvider);
 
-  // Helper to fetch from server and update history
-  Future<Searched> fetchFromServer() async {
-    final data = await repository.getWork(documentID.toString());
-    final isFavorite = await archiveRepo.getFavoriteState(documentID);
-    final combined = data.copyWith(isFavorite: isFavorite, isCached: false);
-
-    // reset force flag if it was true? Legacy code did this.
-    if (forceReload) {
-      ref.read(forceReloadProvider.notifier).state = false;
+    Future<Searched> fetchFromServer() async {
+      final data = await repository.getWork(documentID.toString());
+      final isFavorite = await archiveRepo.getFavoriteState(documentID);
+      final combined = data.copyWith(isFavorite: isFavorite, isCached: false);
+      if (forceReload) {
+        ref.read(forceReloadProvider.notifier).state = false;
+      }
+      await archiveRepo.insertHistory(combined);
+      return combined;
     }
 
-    // Update history
-    await archiveRepo.insertHistory(combined);
-    return combined;
+    final Searched result;
+    if (forceReload) {
+      result = await fetchFromServer();
+    } else {
+      final cached = await archiveRepo.getHistory(documentID);
+      if (cached != null) {
+        result = cached.copyWith(isCached: false);
+      } else {
+        result = await fetchFromServer();
+      }
+    }
+
+    // キャッシュから取得した場合のみ陳腐化チェックを実施
+    if (result.savedAt != null) {
+      unawaited(_refreshLikesIfStale(documentID, result.savedAt!, result));
+    }
+
+    return result;
   }
 
-  if (forceReload) {
-    return fetchFromServer();
-  } else {
-    final cached = await archiveRepo.getHistory(documentID);
-    if (cached != null) {
-      // SQLite は isCached を保存しないため Default(true) になる。
-      // 詳細画面では常に実データとして扱う。
-      return cached.copyWith(isCached: false);
-    } else {
-      return fetchFromServer();
+  Future<void> _refreshLikesIfStale(
+    int documentID,
+    DateTime viewedAt,
+    Searched current,
+  ) async {
+    if (DateTime.now().difference(viewedAt) < const Duration(days: 90)) return;
+
+    if (!ref.mounted) return;
+    ref.read(isRefreshingLikesProvider(documentID).notifier).state = true;
+
+    try {
+      final repository = ref.read(researchWorkRepositoryProvider);
+      final archiveRepo = ref.read(userArchiveRepositoryProvider);
+      final userId = FirebaseAuth.instance.currentUser?.uid;
+
+      final latest = await repository.getWork(documentID.toString());
+      final updated =
+          latest.copyWith(isFavorite: current.isFavorite, isCached: false);
+
+      if (!ref.mounted) return;
+      state = AsyncData(updated);
+
+      if (userId != null) {
+        unawaited(archiveRepo.updateHistoryWork(documentID, updated));
+      }
+    } catch (_) {
+      // バックグラウンド更新の失敗はサイレントに無視
+    } finally {
+      if (ref.mounted) {
+        ref.read(isRefreshingLikesProvider(documentID).notifier).state = false;
+      }
     }
   }
 }
 
-// Keeping the old name for backward compatibility or refactoring UI in next steps
+/// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
+@riverpod
+class IsRefreshingLikes extends _$IsRefreshingLikes {
+  @override
+  bool build(int documentID) => false;
+
+  // ignore: use_setters_to_change_properties
+  void set(bool value) => state = value;
+}
+
+// 後方互換のエイリアス
 final searchedItemProvider = researchWorkProvider;
 
-//choiceChipの選択肢を管理する簡易的なProvider
 final intProvider = StateProvider.autoDispose((ref) => 0);
-final stringProvider =
-    StateProvider.autoDispose<String>((ref) => '22202363'); //TODO 初期値これ升田さんのやつ。
+final stringProvider = StateProvider.autoDispose<String>((ref) => '22202363');

--- a/lib/features/research_work/presentation/providers/searched_provider.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.dart
@@ -71,7 +71,7 @@ class ResearchWork extends _$ResearchWork {
     if (DateTime.now().difference(viewedAt) < const Duration(days: 90)) return;
 
     if (!ref.mounted) return;
-    ref.read(isRefreshingLikesProvider(documentID).notifier).state = true;
+    ref.read(isRefreshingLikesProvider(documentID).notifier).set(true);
 
     try {
       final repository = ref.read(researchWorkRepositoryProvider);
@@ -92,7 +92,7 @@ class ResearchWork extends _$ResearchWork {
       // バックグラウンド更新の失敗はサイレントに無視
     } finally {
       if (ref.mounted) {
-        ref.read(isRefreshingLikesProvider(documentID).notifier).state = false;
+        ref.read(isRefreshingLikesProvider(documentID).notifier).set(false);
       }
     }
   }

--- a/lib/features/research_work/presentation/providers/searched_provider.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.dart
@@ -56,6 +56,13 @@ class ResearchWork extends _$ResearchWork {
     return result;
   }
 
+  /// お気に入り操作後に UI を即時更新する（invalidate による再フェッチを使わない）
+  void updateForFavoriteChange({required bool isFavorite, required int likes}) {
+    state = state.whenData(
+      (s) => s.copyWith(isFavorite: isFavorite, likes: likes),
+    );
+  }
+
   Future<void> _refreshLikesIfStale(
     int documentID,
     DateTime viewedAt,

--- a/lib/features/research_work/presentation/providers/searched_provider.g.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.g.dart
@@ -9,12 +9,11 @@ part of 'searched_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(researchWork)
+@ProviderFor(ResearchWork)
 const researchWorkProvider = ResearchWorkFamily._();
 
-final class ResearchWorkProvider extends $FunctionalProvider<
-        AsyncValue<Searched>, Searched, FutureOr<Searched>>
-    with $FutureModifier<Searched>, $FutureProvider<Searched> {
+final class ResearchWorkProvider
+    extends $AsyncNotifierProvider<ResearchWork, Searched> {
   const ResearchWorkProvider._(
       {required ResearchWorkFamily super.from, required int super.argument})
       : super(
@@ -37,17 +36,7 @@ final class ResearchWorkProvider extends $FunctionalProvider<
 
   @$internal
   @override
-  $FutureProviderElement<Searched> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(pointer);
-
-  @override
-  FutureOr<Searched> create(Ref ref) {
-    final argument = this.argument as int;
-    return researchWork(
-      ref,
-      argument,
-    );
-  }
+  ResearchWork create() => ResearchWork();
 
   @override
   bool operator ==(Object other) {
@@ -60,10 +49,12 @@ final class ResearchWorkProvider extends $FunctionalProvider<
   }
 }
 
-String _$researchWorkHash() => r'ee2409657d34009b311ecdf8f987f999ddbe3738';
+String _$researchWorkHash() => r'feb7e6cdd0cee9e213e887958c11e702d80a0633';
 
 final class ResearchWorkFamily extends $Family
-    with $FunctionalFamilyOverride<FutureOr<Searched>, int> {
+    with
+        $ClassFamilyOverride<ResearchWork, AsyncValue<Searched>, Searched,
+            FutureOr<Searched>, int> {
   const ResearchWorkFamily._()
       : super(
           retry: null,
@@ -80,4 +71,128 @@ final class ResearchWorkFamily extends $Family
 
   @override
   String toString() => r'researchWorkProvider';
+}
+
+abstract class _$ResearchWork extends $AsyncNotifier<Searched> {
+  late final _$args = ref.$arg as int;
+  int get documentID => _$args;
+
+  FutureOr<Searched> build(
+    int documentID,
+  );
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(
+      _$args,
+    );
+    final ref = this.ref as $Ref<AsyncValue<Searched>, Searched>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<AsyncValue<Searched>, Searched>,
+        AsyncValue<Searched>,
+        Object?,
+        Object?>;
+    element.handleValue(ref, created);
+  }
+}
+
+/// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
+
+@ProviderFor(IsRefreshingLikes)
+const isRefreshingLikesProvider = IsRefreshingLikesFamily._();
+
+/// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
+final class IsRefreshingLikesProvider
+    extends $NotifierProvider<IsRefreshingLikes, bool> {
+  /// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
+  const IsRefreshingLikesProvider._(
+      {required IsRefreshingLikesFamily super.from,
+      required int super.argument})
+      : super(
+          retry: null,
+          name: r'isRefreshingLikesProvider',
+          isAutoDispose: true,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$isRefreshingLikesHash();
+
+  @override
+  String toString() {
+    return r'isRefreshingLikesProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  IsRefreshingLikes create() => IsRefreshingLikes();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is IsRefreshingLikesProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$isRefreshingLikesHash() => r'40a12be1a7035124b01fc174a12ae43c4313a683';
+
+/// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
+
+final class IsRefreshingLikesFamily extends $Family
+    with $ClassFamilyOverride<IsRefreshingLikes, bool, bool, bool, int> {
+  const IsRefreshingLikesFamily._()
+      : super(
+          retry: null,
+          name: r'isRefreshingLikesProvider',
+          dependencies: null,
+          $allTransitiveDependencies: null,
+          isAutoDispose: true,
+        );
+
+  /// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
+
+  IsRefreshingLikesProvider call(
+    int documentID,
+  ) =>
+      IsRefreshingLikesProvider._(argument: documentID, from: this);
+
+  @override
+  String toString() => r'isRefreshingLikesProvider';
+}
+
+/// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
+
+abstract class _$IsRefreshingLikes extends $Notifier<bool> {
+  late final _$args = ref.$arg as int;
+  int get documentID => _$args;
+
+  bool build(
+    int documentID,
+  );
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(
+      _$args,
+    );
+    final ref = this.ref as $Ref<bool, bool>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<bool, bool>, bool, Object?, Object?>;
+    element.handleValue(ref, created);
+  }
 }

--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -42,6 +42,22 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
 
   @override
   Widget build(BuildContext context) {
+    // likes のバックグラウンド更新中はスナックバーを表示する
+    ref.listen(isRefreshingLikesProvider(widget.documentID), (prev, next) {
+      final messenger = ScaffoldMessenger.of(context);
+      if (next) {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text('データが古いため更新しています...'),
+            duration: Duration(seconds: 30),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      } else if (prev == true) {
+        messenger.clearSnackBars();
+      }
+    });
+
     final currentIndex = ref.watch(isFullScreenProvider) ? 1 : 0; //全画面表示かどうか
     final AsyncValue<Searched> searched =
         ref.watch(searchedItemProvider(widget.documentID));

--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -22,6 +22,7 @@ class ResultPage extends ConsumerStatefulWidget {
 
 class _ResultPageMainState extends ConsumerState<ResultPage> {
   final ScreenCaptureEvent screenListener = ScreenCaptureEvent();
+  ScaffoldMessengerState? _messenger;
 
   @override
   void initState() {
@@ -36,17 +37,19 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
 
   @override
   void dispose() {
+    _messenger?.clearSnackBars();
     screenListener.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    _messenger = ScaffoldMessenger.of(context);
+
     // likes のバックグラウンド更新中はスナックバーを表示する
     ref.listen(isRefreshingLikesProvider(widget.documentID), (prev, next) {
-      final messenger = ScaffoldMessenger.of(context);
       if (next) {
-        messenger.showSnackBar(
+        _messenger?.showSnackBar(
           const SnackBar(
             content: Text('データが古いため更新しています...'),
             duration: Duration(seconds: 30),
@@ -54,7 +57,7 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
           ),
         );
       } else if (prev == true) {
-        messenger.clearSnackBars();
+        _messenger?.clearSnackBars();
       }
     });
 

--- a/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
+++ b/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
@@ -1,0 +1,132 @@
+import 'package:kenryo_tankyu/core/providers/supabase_provider.dart';
+import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/archive_stats.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'browsing_history_data_source.g.dart';
+
+@Riverpod(keepAlive: true)
+BrowsingHistoryDataSource browsingHistoryDataSource(Ref ref) {
+  return BrowsingHistoryDataSource(ref.watch(supabaseClientProvider));
+}
+
+class BrowsingHistoryDataSource {
+  BrowsingHistoryDataSource(this._client);
+
+  final SupabaseClient _client;
+
+  Future<List<Searched>?> getAllHistory(String userId) async {
+    final rows = await _client
+        .from('browsing_history')
+        .select()
+        .eq('user_id', userId)
+        .order('viewed_at', ascending: false);
+    if (rows.isEmpty) return null;
+    return rows.map((r) => Searched.fromSupabase(r)).toList();
+  }
+
+  Future<List<Searched>?> getHistoryByIds(
+      String userId, Set<int> documentIds) async {
+    if (documentIds.isEmpty) return null;
+    final rows = await _client
+        .from('browsing_history')
+        .select()
+        .eq('user_id', userId)
+        .inFilter('document_id', documentIds.toList())
+        .order('viewed_at', ascending: false);
+    if (rows.isEmpty) return null;
+    return rows.map((r) => Searched.fromSupabase(r, isFavorite: true)).toList();
+  }
+
+  /// 初回閲覧は全フィールドをINSERT、再閲覧はviewed_atのみUPDATE
+  Future<void> recordView(String userId, Searched work) async {
+    final existing = await _client
+        .from('browsing_history')
+        .select('document_id')
+        .eq('user_id', userId)
+        .eq('document_id', work.documentID)
+        .maybeSingle();
+
+    if (existing == null) {
+      await _client.from('browsing_history').insert({
+        'user_id': userId,
+        ...work.toSupabase(),
+        'viewed_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } else {
+      await _client
+          .from('browsing_history')
+          .update({'viewed_at': DateTime.now().toUtc().toIso8601String()})
+          .eq('user_id', userId)
+          .eq('document_id', work.documentID);
+    }
+  }
+
+  Future<Searched?> getHistory(String userId, int documentID) async {
+    final row = await _client
+        .from('browsing_history')
+        .select()
+        .eq('user_id', userId)
+        .eq('document_id', documentID)
+        .maybeSingle();
+    return row == null ? null : Searched.fromSupabase(row);
+  }
+
+  Future<void> deleteHistory(String userId, int documentID) async {
+    await _client
+        .from('browsing_history')
+        .delete()
+        .eq('user_id', userId)
+        .eq('document_id', documentID);
+  }
+
+  Future<void> deleteAllHistory(String userId) async {
+    await _client.from('browsing_history').delete().eq('user_id', userId);
+  }
+
+  Future<void> deleteHistoryBefore(String userId, DateTime date) async {
+    await _client
+        .from('browsing_history')
+        .delete()
+        .eq('user_id', userId)
+        .lt('viewed_at', date.toUtc().toIso8601String());
+  }
+
+  Future<List<DateTime>> getAllViewedDates(String userId) async {
+    final rows = await _client
+        .from('browsing_history')
+        .select('viewed_at')
+        .eq('user_id', userId);
+    return rows
+        .map<DateTime>(
+            (r) => DateTime.parse(r['viewed_at'] as String).toLocal())
+        .toList();
+  }
+
+  Future<HistoryStats> getHistoryStats(String userId) async {
+    final rows = await _client
+        .from('browsing_history')
+        .select('viewed_at')
+        .eq('user_id', userId);
+    if (rows.isEmpty) return (count: 0, oldest: null, newest: null);
+    final dates = rows
+        .map<DateTime>(
+            (r) => DateTime.parse(r['viewed_at'] as String).toLocal())
+        .toList()
+      ..sort();
+    return (count: dates.length, oldest: dates.first, newest: dates.last);
+  }
+
+  /// likes 等の作品データを最新値で更新（viewed_at は変更しない）
+  Future<void> updateWorkInHistory(
+      String userId, int documentID, Searched latest) async {
+    final data = latest.toSupabase();
+    data.remove('document_id');
+    await _client
+        .from('browsing_history')
+        .update(data)
+        .eq('user_id', userId)
+        .eq('document_id', documentID);
+  }
+}

--- a/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
+++ b/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
@@ -39,28 +39,14 @@ class BrowsingHistoryDataSource {
     return rows.map((r) => Searched.fromSupabase(r, isFavorite: true)).toList();
   }
 
-  /// 初回閲覧は全フィールドをINSERT、再閲覧はviewed_atのみUPDATE
+  /// 閲覧履歴を記録する。既存レコードがあれば全フィールドを上書き（upsert）
+  /// recordView は常にサーバーフェッチ直後に呼ばれるため、データは常に最新
   Future<void> recordView(String userId, Searched work) async {
-    final existing = await _client
-        .from('browsing_history')
-        .select('document_id')
-        .eq('user_id', userId)
-        .eq('document_id', work.documentID)
-        .maybeSingle();
-
-    if (existing == null) {
-      await _client.from('browsing_history').insert({
-        'user_id': userId,
-        ...work.toSupabase(),
-        'viewed_at': DateTime.now().toUtc().toIso8601String(),
-      });
-    } else {
-      await _client
-          .from('browsing_history')
-          .update({'viewed_at': DateTime.now().toUtc().toIso8601String()})
-          .eq('user_id', userId)
-          .eq('document_id', work.documentID);
-    }
+    await _client.from('browsing_history').upsert({
+      'user_id': userId,
+      ...work.toSupabase(),
+      'viewed_at': DateTime.now().toUtc().toIso8601String(),
+    });
   }
 
   Future<Searched?> getHistory(String userId, int documentID) async {

--- a/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
+++ b/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
@@ -118,6 +118,23 @@ class BrowsingHistoryDataSource {
     return (count: dates.length, oldest: dates.first, newest: dates.last);
   }
 
+  /// お気に入り操作に伴う likes の差分更新（現在値を取得してから +delta）
+  Future<void> updateLikes(String userId, int documentID, int delta) async {
+    final row = await _client
+        .from('browsing_history')
+        .select('likes')
+        .eq('user_id', userId)
+        .eq('document_id', documentID)
+        .maybeSingle();
+    if (row == null) return;
+    final current = row['likes'] as int;
+    await _client
+        .from('browsing_history')
+        .update({'likes': (current + delta).clamp(0, 999999)})
+        .eq('user_id', userId)
+        .eq('document_id', documentID);
+  }
+
   /// likes 等の作品データを最新値で更新（viewed_at は変更しない）
   Future<void> updateWorkInHistory(
       String userId, int documentID, Searched latest) async {

--- a/lib/features/user_archive/data/datasources/browsing_history_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/browsing_history_data_source.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'browsing_history_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(browsingHistoryDataSource)
+const browsingHistoryDataSourceProvider = BrowsingHistoryDataSourceProvider._();
+
+final class BrowsingHistoryDataSourceProvider extends $FunctionalProvider<
+    BrowsingHistoryDataSource,
+    BrowsingHistoryDataSource,
+    BrowsingHistoryDataSource> with $Provider<BrowsingHistoryDataSource> {
+  const BrowsingHistoryDataSourceProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'browsingHistoryDataSourceProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$browsingHistoryDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<BrowsingHistoryDataSource> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  BrowsingHistoryDataSource create(Ref ref) {
+    return browsingHistoryDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BrowsingHistoryDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BrowsingHistoryDataSource>(value),
+    );
+  }
+}
+
+String _$browsingHistoryDataSourceHash() =>
+    r'9e807e797f910facab19095c99556d247feea364';

--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -172,11 +172,22 @@ class UserArchiveRepositoryImpl
       throw mapException(e);
     }
 
+    // browsing_history の likes をバックグラウンドで更新（失敗しても無視）
+    _updateBrowsingHistoryLikesSilently(
+        userId, documentID, nextIsFavorite ? 1 : -1);
+
     // SQLite の isFavorite も同期（セッション⑥で削除予定）
     await _legacyHistoryDataSource.changeFavoriteState(
         documentID, nextIsFavorite);
     await _legacyHistoryDataSource.updateLikes(
         documentID, nextIsFavorite ? 1 : -1);
+  }
+
+  void _updateBrowsingHistoryLikesSilently(
+      String userId, int documentID, int delta) {
+    _browsingHistoryDataSource
+        .updateLikes(userId, documentID, delta)
+        .catchError((_) {});
   }
 
   @override

--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/error/error_mapper.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/browsing_history_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/favorites_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/recommended_works_local_data_source.dart';
@@ -14,24 +15,29 @@ import 'package:kenryo_tankyu/features/user_archive/domain/repositories/user_arc
 class UserArchiveRepositoryImpl
     with ErrorMapper
     implements UserArchiveRepository {
-  final SearchedHistoryLocalDataSource _historyDataSource;
+  final BrowsingHistoryDataSource _browsingHistoryDataSource;
   final FavoritesRemoteDataSource _favoritesDataSource;
   final PdfLocalDataSource _pdfDataSource;
   final RecommendedWorksLocalDataSource _recommendedDataSource;
   final UserArchiveRemoteDataSource _remoteDataSource;
+  // SQLite の isFavorite 同期用（セッション⑥で削除予定）
+  final SearchedHistoryLocalDataSource _legacyHistoryDataSource;
 
   UserArchiveRepositoryImpl(
-    this._historyDataSource,
+    this._browsingHistoryDataSource,
     this._favoritesDataSource,
     this._pdfDataSource,
     this._recommendedDataSource,
     this._remoteDataSource,
+    this._legacyHistoryDataSource,
   );
 
   @override
   Future<List<Searched>?> getAllHistory() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return null;
     try {
-      return await _historyDataSource.getAllHistory();
+      return await _browsingHistoryDataSource.getAllHistory(userId);
     } catch (e) {
       throw mapException(e);
     }
@@ -44,16 +50,8 @@ class UserArchiveRepositoryImpl
     try {
       final favoriteIds = await _favoritesDataSource.getFavoriteIds(userId);
       if (favoriteIds.isEmpty) return null;
-      // セッション③完了まで SQLite の閲覧履歴を取得源とする。
-      // そのため新デバイスや履歴削除後はお気に入り一覧に表示されない制約がある。
-      // browsing_history の Supabase 移行後に Supabase から直接取得する実装に切り替える。
-      final allHistory = await _historyDataSource.getAllHistory();
-      if (allHistory == null) return null;
-      final favorites = allHistory
-          .where((h) => favoriteIds.contains(h.documentID))
-          .map((h) => h.copyWith(isFavorite: true))
-          .toList();
-      return favorites.isEmpty ? null : favorites;
+      return await _browsingHistoryDataSource.getHistoryByIds(
+          userId, favoriteIds);
     } catch (e) {
       throw mapException(e);
     }
@@ -61,8 +59,10 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<void> insertHistory(Searched searched) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
     try {
-      await _historyDataSource.insertHistory(searched);
+      await _browsingHistoryDataSource.recordView(userId, searched);
     } catch (e) {
       throw mapException(e);
     }
@@ -70,8 +70,10 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<Searched?> getHistory(int documentID) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return null;
     try {
-      return await _historyDataSource.getHistory(documentID);
+      return await _browsingHistoryDataSource.getHistory(userId, documentID);
     } catch (e) {
       throw mapException(e);
     }
@@ -79,8 +81,10 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<void> deleteHistory(int documentID) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
     try {
-      await _historyDataSource.deleteHistory(documentID);
+      await _browsingHistoryDataSource.deleteHistory(userId, documentID);
     } catch (e) {
       throw mapException(e);
     }
@@ -88,8 +92,10 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<void> deleteAllHistory() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
     try {
-      await _historyDataSource.deleteAllHistory();
+      await _browsingHistoryDataSource.deleteAllHistory(userId);
     } catch (e) {
       throw mapException(e);
     }
@@ -97,8 +103,10 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<void> deleteHistoryBefore(DateTime date) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
     try {
-      await _historyDataSource.deleteHistoryBefore(date);
+      await _browsingHistoryDataSource.deleteHistoryBefore(userId, date);
     } catch (e) {
       throw mapException(e);
     }
@@ -106,8 +114,10 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<HistoryStats> getHistoryStats() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return (count: 0, oldest: null, newest: null);
     try {
-      return await _historyDataSource.getHistoryStats();
+      return await _browsingHistoryDataSource.getHistoryStats(userId);
     } catch (e) {
       throw mapException(e);
     }
@@ -115,8 +125,22 @@ class UserArchiveRepositoryImpl
 
   @override
   Future<List<DateTime>> getAllHistorySavedDates() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return [];
     try {
-      return await _historyDataSource.getAllSavedDates();
+      return await _browsingHistoryDataSource.getAllViewedDates(userId);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<void> updateHistoryWork(int documentID, Searched latest) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
+    try {
+      await _browsingHistoryDataSource.updateWorkInHistory(
+          userId, documentID, latest);
     } catch (e) {
       throw mapException(e);
     }
@@ -149,8 +173,10 @@ class UserArchiveRepositoryImpl
     }
 
     // SQLite の isFavorite も同期（セッション⑥で削除予定）
-    await _historyDataSource.changeFavoriteState(documentID, nextIsFavorite);
-    await _historyDataSource.updateLikes(documentID, nextIsFavorite ? 1 : -1);
+    await _legacyHistoryDataSource.changeFavoriteState(
+        documentID, nextIsFavorite);
+    await _legacyHistoryDataSource.updateLikes(
+        documentID, nextIsFavorite ? 1 : -1);
   }
 
   @override

--- a/lib/features/user_archive/domain/repositories/user_archive_repository.dart
+++ b/lib/features/user_archive/domain/repositories/user_archive_repository.dart
@@ -14,6 +14,7 @@ abstract class UserArchiveRepository {
   Future<void> deleteHistoryBefore(DateTime date);
   Future<HistoryStats> getHistoryStats();
   Future<List<DateTime>> getAllHistorySavedDates();
+  Future<void> updateHistoryWork(int documentID, Searched latest);
 
   // Favorite (combines local DB and potentially remote updates)
   Future<void> changeFavoriteState(int documentID, bool nextIsFavorite);

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -5,6 +5,7 @@ import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/providers/searched_provider.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/browsing_history_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/favorites_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/recommended_works_local_data_source.dart';
@@ -19,19 +20,24 @@ part 'user_archive_providers.g.dart';
 
 @riverpod
 UserArchiveRepository userArchiveRepository(Ref ref) {
-  final historyDataSource = ref.watch(searchedHistoryLocalDataSourceProvider);
+  final browsingHistoryDataSource =
+      ref.watch(browsingHistoryDataSourceProvider);
   final favoritesDataSource = ref.watch(favoritesRemoteDataSourceProvider);
   final pdfDataSource = ref.watch(pdfLocalDataSourceProvider);
   final recommendedDataSource =
       ref.watch(recommendedWorksLocalDataSourceProvider);
   final remoteDataSource = ref.watch(userArchiveRemoteDataSourceProvider);
+  // SQLite の isFavorite 同期用（セッション⑥で削除予定）
+  final legacyHistoryDataSource =
+      ref.watch(searchedHistoryLocalDataSourceProvider);
 
   return UserArchiveRepositoryImpl(
-    historyDataSource,
+    browsingHistoryDataSource,
     favoritesDataSource,
     pdfDataSource,
     recommendedDataSource,
     remoteDataSource,
+    legacyHistoryDataSource,
   );
 }
 
@@ -137,7 +143,13 @@ Future<List<Searched>?> searchedHistory(Ref ref, bool onlyShowFavorite) async {
   if (onlyShowFavorite) {
     return repository.getFavoriteHistory();
   } else {
-    return repository.getAllHistory();
+    final history = await repository.getAllHistory();
+    if (history == null) return null;
+    // FavoriteIdsCache はインメモリキャッシュなので Supabase を叩かない
+    final favoriteIds = ref.read(favoriteIdsCacheProvider);
+    return history
+        .map((h) => h.copyWith(isFavorite: favoriteIds.contains(h.documentID)))
+        .toList();
   }
 }
 

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -101,9 +101,22 @@ class UserIsFavoriteState extends _$UserIsFavoriteState {
         ref.read(favoriteIdsCacheProvider.notifier).remove(documentID);
       }
 
-      // 関連するProviderを無効化
+      // 履歴一覧を無効化
       ref.invalidate(searchedHistoryProvider);
-      ref.invalidate(researchWorkProvider(documentID));
+
+      // researchWork の state を直接更新（invalidate だと browsing_history の
+      // キャッシュ更新タイミングと競合して古い likes が表示されるため）
+      final current = ref.read(researchWorkProvider(documentID)).asData?.value;
+      if (current != null) {
+        final newLikes =
+            (current.likes + (nextIsFavorite ? 1 : -1)).clamp(0, 999999);
+        ref
+            .read(researchWorkProvider(documentID).notifier)
+            .updateForFavoriteChange(
+              isFavorite: nextIsFavorite,
+              likes: newLikes,
+            );
+      }
 
       return nextIsFavorite;
     });

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
@@ -51,7 +51,7 @@ final class UserArchiveRepositoryProvider extends $FunctionalProvider<
 }
 
 String _$userArchiveRepositoryHash() =>
-    r'f843658a661f0d403b10a7a029dbfcca65e30650';
+    r'3144510063e2dec0a0491edf826b82ec6e79712e';
 
 @ProviderFor(FavoriteIdsCache)
 const favoriteIdsCacheProvider = FavoriteIdsCacheProvider._();
@@ -85,7 +85,7 @@ final class FavoriteIdsCacheProvider
   }
 }
 
-String _$favoriteIdsCacheHash() => r'3cf55c7e5b5cf6e2fd26a951de32b2c8c7c450c3';
+String _$favoriteIdsCacheHash() => r'601decced1c010a9a800c8bdc9a85aa7463d33e4';
 
 abstract class _$FavoriteIdsCache extends $Notifier<Set<int>> {
   Set<int> build();


### PR DESCRIPTION
## 概要
`browsing_history` テーブルへの読み書きを実装し、SQLite 版の閲覧履歴を Supabase に完全移行する。
likes の陳腐化対策として、詳細画面表示時に90日以上前のレコードを Firestore から取得して更新する仕組みも追加した。

## 種別
- [x] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
なし

## 変更内容

### 新規ファイル
- `browsing_history_data_source.dart` — Supabase `browsing_history` テーブルのアクセス層
  - 初回閲覧: 全フィールドを INSERT
  - 再閲覧: `viewed_at` のみ UPDATE（転送量を最小化）
  - `updateWorkInHistory()`: likes 等のメタデータを最新値で更新（`viewed_at` は変更しない）

### 変更ファイル
- `searched.dart` — `toSupabase()` / `fromSupabase()` を追加
- `user_archive_repository.dart` — `updateHistoryWork()` をインターフェースに追加
- `user_archive_repository_impl.dart` — 履歴メソッドを `BrowsingHistoryDataSource` に差し替え（SQLite の `isFavorite` 同期はセッション⑥まで維持）
- `user_archive_providers.dart`
  - `userArchiveRepository` に `BrowsingHistoryDataSource` を DI
  - `searchedHistory` プロバイダで `FavoriteIdsCache`（インメモリ）を使って isFavorite を付与（Supabase への余分なリクエストを削除）
- `searched_provider.dart` — `researchWork` を class-based Notifier に変換し、90日以上前のキャッシュを Firestore で再取得して更新するロジックを追加
- `result_page.dart` — バックグラウンド更新中に「データが古いため更新しています...」スナックバーを表示

## スクリーンショット
なし（UIの見た目変更なし。スナックバーは90日以上前のキャッシュを表示したときのみ出現）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし（`flutter analyze`: No issues found）
- [ ] テストを追加または更新済み（必要な場合）