### PR TITLE
[Supabase] 検索履歴をSupabaseに移行

### DIFF
--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -33,9 +33,7 @@ class AuthNotifier extends _$AuthNotifier {
               ref.read(favoriteIdsCacheProvider.notifier).initialize(user.uid),
             );
             unawaited(
-              ref
-                  .read(searchHistoryCacheProvider.notifier)
-                  .initialize(user.uid),
+              ref.read(searchHistoryCacheProvider.notifier).initialize(),
             );
           } else {
             ref.invalidate(favoriteIdsCacheProvider);

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -6,6 +6,7 @@ import 'package:kenryo_tankyu/features/auth/presentation/providers/user_reposito
 import 'package:kenryo_tankyu/features/auth/domain/models/auth.dart';
 import 'package:kenryo_tankyu/features/notification/data/datasources/notification_db.dart';
 import 'package:kenryo_tankyu/features/search/data/datasources/search_history_data_source.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_provider.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/searched_history_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
@@ -31,8 +32,14 @@ class AuthNotifier extends _$AuthNotifier {
             unawaited(
               ref.read(favoriteIdsCacheProvider.notifier).initialize(user.uid),
             );
+            unawaited(
+              ref
+                  .read(searchHistoryCacheProvider.notifier)
+                  .initialize(user.uid),
+            );
           } else {
             ref.invalidate(favoriteIdsCacheProvider);
+            ref.invalidate(searchHistoryCacheProvider);
           }
         });
       },
@@ -137,6 +144,7 @@ class AuthNotifier extends _$AuthNotifier {
     }
     // アカウント削除成功後、全ローカルデータを消去（失敗してもアカウント削除は成功とみなす）
     await _clearAllLocalData(
+      userId: user.uid,
       searchedHistoryDs: searchedHistoryDs,
       pdfDs: pdfDs,
       searchHistoryDs: searchHistoryDs,
@@ -144,6 +152,7 @@ class AuthNotifier extends _$AuthNotifier {
   }
 
   Future<void> _clearAllLocalData({
+    required String userId,
     required SearchedHistoryLocalDataSource searchedHistoryDs,
     required PdfLocalDataSource pdfDs,
     required SearchHistoryDataSource searchHistoryDs,
@@ -155,7 +164,7 @@ class AuthNotifier extends _$AuthNotifier {
       await pdfDs.deleteAllPdf();
     } catch (_) {}
     try {
-      await searchHistoryDs.deleteAllHistory();
+      await searchHistoryDs.deleteAllHistory(userId);
     } catch (_) {}
     try {
       await NotificationDbController.deleteAllNotifications();

--- a/lib/features/auth/presentation/providers/auth_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.g.dart
@@ -73,7 +73,7 @@ final class AuthNotifierProvider extends $NotifierProvider<AuthNotifier, Auth> {
   }
 }
 
-String _$authNotifierHash() => r'8eda0dd8acfa00020900948de29acd646ccaa2e9';
+String _$authNotifierHash() => r'623d08ae1c0650494b1b327ece4ab7b12a647019';
 
 abstract class _$AuthNotifier extends $Notifier<Auth> {
   Auth build();

--- a/lib/features/research_work/presentation/providers/searched_provider.g.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.g.dart
@@ -49,7 +49,7 @@ final class ResearchWorkProvider
   }
 }
 
-String _$researchWorkHash() => r'feb7e6cdd0cee9e213e887958c11e702d80a0633';
+String _$researchWorkHash() => r'dec96d425254ca79b9454e8db6f869338eb267fb';
 
 final class ResearchWorkFamily extends $Family
     with

--- a/lib/features/search/data/datasources/search_history_data_source.dart
+++ b/lib/features/search/data/datasources/search_history_data_source.dart
@@ -1,68 +1,77 @@
+import 'dart:convert';
+
+import 'package:kenryo_tankyu/core/constants/work/category_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/sub_category_value.dart';
+import 'package:kenryo_tankyu/core/providers/supabase_provider.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:sqflite/sqflite.dart';
-// ignore: depend_on_referenced_packages
-import 'package:path/path.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'search_history_data_source.g.dart';
 
-class SearchHistoryDataSource {
-  static final SearchHistoryDataSource _instance = SearchHistoryDataSource._();
-  SearchHistoryDataSource._();
-  static SearchHistoryDataSource get instance => _instance;
-
-  Future<Database> get database async {
-    try {
-      return openDatabase(
-        join(await getDatabasesPath(), 'search_history.db'),
-        onCreate: (db, version) {
-          return db.execute('CREATE TABLE search_history('
-              'id INTEGER PRIMARY KEY AUTOINCREMENT,'
-              'category TEXT NOT NULL DEFAULT "", '
-              'subCategory TEXT NOT NULL DEFAULT "", '
-              'enterYear INTEGER NOT NULL DEFAULT 0, '
-              'eventName TEXT NOT NULL DEFAULT "", '
-              'course TEXT NOT NULL DEFAULT "", '
-              'searchWord TEXT NOT NULL DEFAULT "", '
-              'savedAt TEXT NOT NULL, '
-              'numberOfHits INTEGER NOT NULL DEFAULT 0, '
-              'CHECK(category != "" OR subCategory != "" OR enterYear != 0 OR eventName != "" OR course != "" OR searchWord != "") '
-              'UNIQUE(category, subCategory, enterYear, eventName, course, searchWord) '
-              ');');
-        },
-        version: 21,
-      );
-    } catch (error, stackTrace) {
-      return Future.error(error, stackTrace);
-    }
-  }
-
-  Future<void> deleteAllHistory() async {
-    final Database db = await database;
-    await db.delete('search_history');
-  }
-
-  Future<void> insertHistory(Search search) async {
-    final Database db = await database;
-    await db.insert(
-      'search_history',
-      search.toJson(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
-  }
-
-  Future<List<Search>?> getAllHistory() async {
-    final Database db = await database;
-    final List<Map<String, dynamic>> maps =
-        await db.query('search_history', orderBy: 'savedAt DESC');
-    if (maps.isEmpty) {
-      return null;
-    }
-    return List.generate(maps.length, (i) => Search.fromJson(maps[i]));
-  }
+@Riverpod(keepAlive: true)
+SearchHistoryDataSource searchHistoryDataSource(Ref ref) {
+  return SearchHistoryDataSource(ref.watch(supabaseClientProvider));
 }
 
-@riverpod
-SearchHistoryDataSource searchHistoryDataSource(Ref ref) {
-  return SearchHistoryDataSource.instance;
+class SearchHistoryDataSource {
+  SearchHistoryDataSource(this._client);
+
+  final SupabaseClient _client;
+
+  Future<void> insertHistory(String userId, Search search) async {
+    await _client.from('search_history').upsert(
+          _toRow(userId, search),
+          onConflict:
+              'user_id,category,sub_category,enter_year,event_name,course,search_word',
+        );
+  }
+
+  Future<List<Search>?> getAllHistory(String userId) async {
+    final rows = await _client
+        .from('search_history')
+        .select()
+        .eq('user_id', userId)
+        .order('searched_at', ascending: false);
+    if (rows.isEmpty) return null;
+    return rows.map(_fromRow).toList();
+  }
+
+  Future<void> deleteAllHistory(String userId) async {
+    await _client.from('search_history').delete().eq('user_id', userId);
+  }
+
+  Map<String, dynamic> _toRow(String userId, Search search) => {
+        'user_id': userId,
+        'category': const CategoryEnumConverter().toJson(search.category),
+        'sub_category':
+            const SubCategoryEnumConverter().toJson(search.subCategory),
+        'enter_year': const EnterYearEnumConverter().toJson(search.enterYear),
+        'event_name': const EventNameEnumConverter().toJson(search.eventName),
+        'course': const CourseEnumConverter().toJson(search.course),
+        'search_word': jsonEncode(search.searchWord),
+        'number_of_hits': search.numberOfHits,
+        'searched_at':
+            (search.savedAt ?? DateTime.now()).toUtc().toIso8601String(),
+      };
+
+  Search _fromRow(Map<String, dynamic> row) => Search(
+        category:
+            const CategoryEnumConverter().fromJson(row['category'] as String),
+        subCategory: const SubCategoryEnumConverter()
+            .fromJson(row['sub_category'] as String),
+        enterYear:
+            const EnterYearEnumConverter().fromJson(row['enter_year'] as int),
+        eventName: const EventNameEnumConverter()
+            .fromJson(row['event_name'] as String),
+        course: const CourseEnumConverter().fromJson(row['course'] as String),
+        searchWord: (jsonDecode(row['search_word'] as String) as List)
+            .map((e) => e.toString())
+            .toList(),
+        numberOfHits: (row['number_of_hits'] as int?) ?? 0,
+        savedAt: row['searched_at'] != null
+            ? DateTime.parse(row['searched_at'] as String).toLocal()
+            : null,
+      );
 }

--- a/lib/features/search/data/datasources/search_history_data_source.g.dart
+++ b/lib/features/search/data/datasources/search_history_data_source.g.dart
@@ -22,7 +22,7 @@ final class SearchHistoryDataSourceProvider extends $FunctionalProvider<
           argument: null,
           retry: null,
           name: r'searchHistoryDataSourceProvider',
-          isAutoDispose: true,
+          isAutoDispose: false,
           dependencies: null,
           $allTransitiveDependencies: null,
         );
@@ -51,4 +51,4 @@ final class SearchHistoryDataSourceProvider extends $FunctionalProvider<
 }
 
 String _$searchHistoryDataSourceHash() =>
-    r'cefca60f2848d1cc70192dc8f9fb67f5afd059dd';
+    r'9b1cb3506770eb4c2c7dcfd2928cda0b74aea32a';

--- a/lib/features/search/data/repositories/search_history_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_history_repository_impl.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kenryo_tankyu/core/error/error_mapper.dart';
 import 'package:kenryo_tankyu/features/search/data/datasources/search_history_data_source.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
@@ -11,8 +12,10 @@ class SearchHistoryRepositoryImpl
 
   @override
   Future<void> deleteAllHistory() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
     try {
-      await _dataSource.deleteAllHistory();
+      await _dataSource.deleteAllHistory(userId);
     } catch (e) {
       throw mapException(e);
     }
@@ -20,8 +23,10 @@ class SearchHistoryRepositoryImpl
 
   @override
   Future<List<Search>?> getAllHistory() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return null;
     try {
-      return await _dataSource.getAllHistory();
+      return await _dataSource.getAllHistory(userId);
     } catch (e) {
       throw mapException(e);
     }
@@ -29,8 +34,10 @@ class SearchHistoryRepositoryImpl
 
   @override
   Future<void> insertHistory(Search search) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
     try {
-      await _dataSource.insertHistory(search);
+      await _dataSource.insertHistory(userId, search);
     } catch (e) {
       throw mapException(e);
     }

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -9,6 +9,7 @@ import 'package:kenryo_tankyu/features/search/presentation/providers/search_prov
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:kenryo_tankyu/core/connectivity/connectivity_provider.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_provider.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_repository_provider.dart';
 
 final forceRefreshProvider = StateProvider.autoDispose<bool>((ref) => false);
@@ -75,8 +76,10 @@ final algoliaSearchProvider =
 
   if (result != null && page == 0) {
     // Save history side effect (first page only)
-    await historyRepository.insertHistory(
-        search.copyWith(savedAt: DateTime.now(), numberOfHits: result.nbHits));
+    final searchWithMeta =
+        search.copyWith(savedAt: DateTime.now(), numberOfHits: result.nbHits);
+    await historyRepository.insertHistory(searchWithMeta);
+    ref.read(searchHistoryCacheProvider.notifier).addOrUpdate(searchWithMeta);
   }
 
   if (result == null && page > 0) {

--- a/lib/features/search/presentation/providers/search_history_provider.dart
+++ b/lib/features/search/presentation/providers/search_history_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_repository_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -12,7 +11,7 @@ class SearchHistoryCache extends _$SearchHistoryCache {
   @override
   Future<List<Search>?> build() async => null;
 
-  Future<void> initialize(String userId) async {
+  Future<void> initialize() async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(
       () => ref.read(searchHistoryRepositoryProvider).getAllHistory(),
@@ -20,9 +19,7 @@ class SearchHistoryCache extends _$SearchHistoryCache {
   }
 
   Future<void> reload() async {
-    final userId = FirebaseAuth.instance.currentUser?.uid;
-    if (userId == null) return;
-    await initialize(userId);
+    await initialize();
   }
 
   void addOrUpdate(Search search) {

--- a/lib/features/search/presentation/providers/search_history_provider.dart
+++ b/lib/features/search/presentation/providers/search_history_provider.dart
@@ -1,12 +1,48 @@
-import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_repository_provider.dart';
+import 'dart:convert';
+
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_repository_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'search_history_provider.g.dart';
 
-// SearchHistoryController provider is removed. Use searchHistoryRepositoryProvider.
+@Riverpod(keepAlive: true)
+class SearchHistoryCache extends _$SearchHistoryCache {
+  @override
+  Future<List<Search>?> build() async => null;
 
-@riverpod
-Future<List<Search>?> searchHistory(Ref ref) async {
-  return await ref.watch(searchHistoryRepositoryProvider).getAllHistory();
+  Future<void> initialize(String userId) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => ref.read(searchHistoryRepositoryProvider).getAllHistory(),
+    );
+  }
+
+  Future<void> reload() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
+    await initialize(userId);
+  }
+
+  void addOrUpdate(Search search) {
+    final current = state.asData?.value ?? [];
+    final idx = current.indexWhere((s) => _isSameSearch(s, search));
+    if (idx >= 0) {
+      final updated = List<Search>.from(current)..removeAt(idx);
+      state = AsyncData([search, ...updated]);
+    } else {
+      state = AsyncData([search, ...current]);
+    }
+  }
+
+  void clear() => state = const AsyncData(null);
+
+  bool _isSameSearch(Search a, Search b) =>
+      a.category == b.category &&
+      a.subCategory == b.subCategory &&
+      a.enterYear == b.enterYear &&
+      a.eventName == b.eventName &&
+      a.course == b.course &&
+      jsonEncode(a.searchWord) == jsonEncode(b.searchWord);
 }

--- a/lib/features/search/presentation/providers/search_history_provider.g.dart
+++ b/lib/features/search/presentation/providers/search_history_provider.g.dart
@@ -9,36 +9,45 @@ part of 'search_history_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(searchHistory)
-const searchHistoryProvider = SearchHistoryProvider._();
+@ProviderFor(SearchHistoryCache)
+const searchHistoryCacheProvider = SearchHistoryCacheProvider._();
 
-final class SearchHistoryProvider extends $FunctionalProvider<
-        AsyncValue<List<Search>?>, List<Search>?, FutureOr<List<Search>?>>
-    with $FutureModifier<List<Search>?>, $FutureProvider<List<Search>?> {
-  const SearchHistoryProvider._()
+final class SearchHistoryCacheProvider
+    extends $AsyncNotifierProvider<SearchHistoryCache, List<Search>?> {
+  const SearchHistoryCacheProvider._()
       : super(
           from: null,
           argument: null,
           retry: null,
-          name: r'searchHistoryProvider',
-          isAutoDispose: true,
+          name: r'searchHistoryCacheProvider',
+          isAutoDispose: false,
           dependencies: null,
           $allTransitiveDependencies: null,
         );
 
   @override
-  String debugGetCreateSourceHash() => _$searchHistoryHash();
+  String debugGetCreateSourceHash() => _$searchHistoryCacheHash();
 
   @$internal
   @override
-  $FutureProviderElement<List<Search>?> $createElement(
-          $ProviderPointer pointer) =>
-      $FutureProviderElement(pointer);
-
-  @override
-  FutureOr<List<Search>?> create(Ref ref) {
-    return searchHistory(ref);
-  }
+  SearchHistoryCache create() => SearchHistoryCache();
 }
 
-String _$searchHistoryHash() => r'190059a1cf94a37129ccf87ea95d045eee0e5c5c';
+String _$searchHistoryCacheHash() =>
+    r'5bf10a914eeff6caec88d2c7ea9f7fb8f3fc3b3e';
+
+abstract class _$SearchHistoryCache extends $AsyncNotifier<List<Search>?> {
+  FutureOr<List<Search>?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<List<Search>?>, List<Search>?>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<AsyncValue<List<Search>?>, List<Search>?>,
+        AsyncValue<List<Search>?>,
+        Object?,
+        Object?>;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/search/presentation/screens/search_page.dart
+++ b/lib/features/search/presentation/screens/search_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/constants/work/sub_category_value.dart';
-import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_repository_provider.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_provider.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_repository_provider.dart';
 import 'package:kenryo_tankyu/core/constants/work/category_value.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
 
@@ -98,12 +98,16 @@ class SearchPage extends ConsumerWidget {
                                 child: const Text('キャンセル'),
                               ),
                               TextButton(
-                                onPressed: () {
-                                  ref
+                                onPressed: () async {
+                                  await ref
                                       .read(searchHistoryRepositoryProvider)
                                       .deleteAllHistory();
-                                  ref.invalidate(searchHistoryProvider);
-                                  Navigator.of(context).pop();
+                                  ref
+                                      .read(searchHistoryCacheProvider.notifier)
+                                      .clear();
+                                  if (context.mounted) {
+                                    Navigator.of(context).pop();
+                                  }
                                 },
                                 child: const Text('削除'),
                               ),

--- a/lib/features/search/presentation/widgets/search_history_list.dart
+++ b/lib/features/search/presentation/widgets/search_history_list.dart
@@ -5,15 +5,15 @@ import "package:kenryo_tankyu/core/constants/work/info_value.dart";
 import "package:kenryo_tankyu/core/constants/work/category_value.dart";
 import "package:kenryo_tankyu/core/constants/work/sub_category_value.dart";
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
-import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_provider.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 
 class SearchHistoryList extends ConsumerWidget {
   const SearchHistoryList({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final historyAsyncValue = ref.watch(searchHistoryProvider);
+    final historyAsyncValue = ref.watch(searchHistoryCacheProvider);
     return historyAsyncValue.when(
         data: (searches) {
           return searches == null
@@ -23,7 +23,9 @@ class SearchHistoryList extends ConsumerWidget {
                     const Text('検索履歴はありません。'),
                     const SizedBox(height: 20),
                     ElevatedButton(
-                        onPressed: () => ref.invalidate(searchHistoryProvider),
+                        onPressed: () => ref
+                            .read(searchHistoryCacheProvider.notifier)
+                            .reload(),
                         child: const Text('リロードする')),
                   ],
                 )

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
@@ -196,7 +196,7 @@ final class UserIsFavoriteStateProvider
 }
 
 String _$userIsFavoriteStateHash() =>
-    r'c478737a523ceebc50049715c72d38d5d0d00fc9';
+    r'f2756f3f96e88d606957700f9a7be88d089bf311';
 
 final class UserIsFavoriteStateFamily extends $Family
     with
@@ -295,7 +295,7 @@ final class SearchedHistoryProvider extends $FunctionalProvider<
   }
 }
 
-String _$searchedHistoryHash() => r'fd22fd316566e36e9625f532e610097f8e1a7382';
+String _$searchedHistoryHash() => r'f413d39021c6d21fe54b9e7ad1b1bbd826e1de71';
 
 final class SearchedHistoryFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<Searched>?>, bool> {


### PR DESCRIPTION
## 概要
SQLiteの `search_history.db` をSupabaseの `search_history` テーブルへ移行。
ログイン時に1回だけ取得してキャッシュするRiverpod Notifierを追加し、
検索実行ごとのupsertで即時反映する。

## 種別
- [x] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #  

## 変更内容

### DataSource
- `search_history_data_source.dart`: SQLiteシングルトンを廃止し、`SupabaseClient` を受け取るクラスに全面置き換え
  - `insertHistory(userId, search)` → UNIQUEキー `(user_id, category, sub_category, enter_year, event_name, course, search_word)` によるupsert
  - `getAllHistory(userId)` → `searched_at DESC` 順で取得
  - `deleteAllHistory(userId)` → user_id 単位で削除
  - `search_word` はJSON文字列（`jsonEncode`）としてTEXTカラムに保存（SQLite版と同形式）

### Repository
- `search_history_repository_impl.dart`: `FirebaseAuth.instance.currentUser?.uid` でuserIdを取得しDataSourceへ渡す

### Riverpodキャッシュ
- `search_history_provider.dart`: `searchHistoryProvider`（毎回fetchするFutureProvider）を削除し、`SearchHistoryCacheNotifier` （`keepAlive: true` AsyncNotifier）に一本化
  - `initialize(userId)`: ログイン確定後に1回だけSupabaseから取得
  - `reload()`: 「リロードする」ボタン用。FirebaseAuthから現在ユーザーを取得して再fetch
  - `addOrUpdate(search)`: 検索実行後にUI即時反映（楽観的更新）
  - `clear()`: 全削除・ログアウト時にキャッシュをリセット

### 呼び出し側
- `auth_provider.dart`: ログイン確定時に `searchHistoryCacheProvider.initialize(uid)` を呼ぶ。ログアウト/アカウント削除時に `invalidate`/`deleteAllHistory(uid)` を実行
- `algolia_provider.dart`: 検索実行（page=0）後に `searchHistoryCacheProvider.notifier.addOrUpdate(...)` でキャッシュを楽観的更新
- `search_history_list.dart`: `searchHistoryCacheProvider` を直接 watch
- `search_page.dart`: 全削除ボタンが `searchHistoryCacheProvider.notifier.clear()` を呼ぶよう変更

## スクリーンショット
なし（UIの見た目変更なし）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし（`flutter analyze` でNo issues found）
- [ ] テストを追加または更新済み（必要な場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)