### PR TITLE
[Notification] 通知既読状態をSupabaseに移行

### DIFF
--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -5,6 +5,7 @@ import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_reposito
 import 'package:kenryo_tankyu/features/auth/presentation/providers/user_repository_provider.dart';
 import 'package:kenryo_tankyu/features/auth/domain/models/auth.dart';
 import 'package:kenryo_tankyu/features/notification/data/datasources/notification_db.dart';
+import 'package:kenryo_tankyu/features/notification/presentation/providers/read_notification_ids_provider.dart';
 import 'package:kenryo_tankyu/features/search/data/datasources/search_history_data_source.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_provider.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
@@ -35,9 +36,15 @@ class AuthNotifier extends _$AuthNotifier {
             unawaited(
               ref.read(searchHistoryCacheProvider.notifier).initialize(),
             );
+            unawaited(
+              ref
+                  .read(readNotificationIdsProvider.notifier)
+                  .initialize(user.uid),
+            );
           } else {
             ref.invalidate(favoriteIdsCacheProvider);
             ref.invalidate(searchHistoryCacheProvider);
+            ref.invalidate(readNotificationIdsProvider);
           }
         });
       },

--- a/lib/features/auth/presentation/providers/auth_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.g.dart
@@ -73,7 +73,7 @@ final class AuthNotifierProvider extends $NotifierProvider<AuthNotifier, Auth> {
   }
 }
 
-String _$authNotifierHash() => r'623d08ae1c0650494b1b327ece4ab7b12a647019';
+String _$authNotifierHash() => r'6d01c67c64cea1181eba92b2cd2ffd8f45ee4246';
 
 abstract class _$AuthNotifier extends $Notifier<Auth> {
   Auth build();

--- a/lib/features/notification/data/datasources/notification_db.dart
+++ b/lib/features/notification/data/datasources/notification_db.dart
@@ -66,8 +66,10 @@ class NotificationDbController {
             );
           }
           if (oldVersion < 4) {
-            // isRead列をSupabaseに移行するため、notificationテーブルを再作成
-            await db.execute('DROP TABLE IF EXISTS notification');
+            // isRead列をSupabaseに移行するため、既存データを保持しつつテーブルを再作成
+            await db.execute(
+              'ALTER TABLE notification RENAME TO notification_old',
+            );
             await db.execute(
               'CREATE TABLE notification('
               'id INTEGER PRIMARY KEY AUTOINCREMENT,'
@@ -80,6 +82,11 @@ class NotificationDbController {
               'CHECK(title != "" OR contents != "") '
               ');',
             );
+            await db.execute(
+              'INSERT INTO notification (id, type, title, contents, sendAt, savedAt, headerImage) '
+              'SELECT id, type, title, contents, sendAt, savedAt, headerImage FROM notification_old',
+            );
+            await db.execute('DROP TABLE IF EXISTS notification_old');
           }
         },
         version: 4,

--- a/lib/features/notification/data/datasources/notification_db.dart
+++ b/lib/features/notification/data/datasources/notification_db.dart
@@ -45,7 +45,6 @@ class NotificationDbController {
             'contents TEXT NOT NULL, '
             'sendAt TEXT NOT NULL, '
             'savedAt TEXT NOT NULL, '
-            'isRead INTEGER NOT NULL, '
             'headerImage BLOB, '
             'CHECK(title != "" OR contents != "") '
             ');',
@@ -58,9 +57,6 @@ class NotificationDbController {
           );
         },
         onUpgrade: (db, oldVersion, newVersion) async {
-          if (oldVersion < 2) {
-            // バージョン2での変更があればここに記述
-          }
           if (oldVersion < 3) {
             await db.execute(
               'CREATE TABLE $tableSettings('
@@ -69,8 +65,24 @@ class NotificationDbController {
               ');',
             );
           }
+          if (oldVersion < 4) {
+            // isRead列をSupabaseに移行するため、notificationテーブルを再作成
+            await db.execute('DROP TABLE IF EXISTS notification');
+            await db.execute(
+              'CREATE TABLE notification('
+              'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+              'type TEXT NOT NULL, '
+              'title TEXT NOT NULL, '
+              'contents TEXT NOT NULL, '
+              'sendAt TEXT NOT NULL, '
+              'savedAt TEXT NOT NULL, '
+              'headerImage BLOB, '
+              'CHECK(title != "" OR contents != "") '
+              ');',
+            );
+          }
         },
-        version: 3,
+        version: 4,
       );
     } catch (error, stackTrace) {
       return Future.error(error, stackTrace);
@@ -120,24 +132,6 @@ class NotificationDbController {
     return List.generate(maps.length, (i) {
       return NotificationContent.fromSQLite(maps[i]);
     });
-  }
-
-  static Future<void> markAsRead(int id) async {
-    final Database db = await database;
-    await db.update(
-      'notification',
-      {'isRead': 1},
-      where: 'id = ?',
-      whereArgs: [id],
-    );
-  }
-
-  static Future<void> markAsReadAll() async {
-    final Database db = await database;
-    await db.update(
-      'notification',
-      {'isRead': 1},
-    );
   }
 
   static Future<void> deleteAllNotifications() async {

--- a/lib/features/notification/data/datasources/notification_local_data_source.dart
+++ b/lib/features/notification/data/datasources/notification_local_data_source.dart
@@ -6,18 +6,12 @@ part 'notification_local_data_source.g.dart';
 
 abstract class NotificationLocalDataSource {
   Future<List<NotificationContent>?> read(int paging);
-  Future<void> markAsRead(int id);
 }
 
 class NotificationLocalDataSourceImpl implements NotificationLocalDataSource {
   @override
   Future<List<NotificationContent>?> read(int paging) {
     return NotificationDbController.read(paging);
-  }
-
-  @override
-  Future<void> markAsRead(int id) {
-    return NotificationDbController.markAsRead(id);
   }
 }
 

--- a/lib/features/notification/data/repositories/notification_repository_impl.dart
+++ b/lib/features/notification/data/repositories/notification_repository_impl.dart
@@ -30,15 +30,6 @@ class NotificationRepositoryImpl
       throw mapException(e);
     }
   }
-
-  @override
-  Future<void> markAsRead(int id) async {
-    try {
-      await _localDataSource.markAsRead(id);
-    } catch (e) {
-      throw mapException(e);
-    }
-  }
 }
 
 @riverpod

--- a/lib/features/notification/domain/models/notification_content.dart
+++ b/lib/features/notification/domain/models/notification_content.dart
@@ -19,7 +19,6 @@ abstract class NotificationContent with _$NotificationContent {
     required String contents,
     @DateTimeConverter() required DateTime sendAt,
     @DateTimeConverter() required DateTime savedAt,
-    required bool isRead,
   }) = _NotificationContent;
 
   factory NotificationContent.fromJson(Map<String, dynamic> json) =>
@@ -27,25 +26,16 @@ abstract class NotificationContent with _$NotificationContent {
 
   factory NotificationContent.fromSQLite(Map<String, dynamic> json) {
     final mutableJson = Map<String, dynamic>.from(json);
-    mutableJson['isRead'] = mutableJson['isRead'] == 1;
-    final notification = NotificationContent.fromJson(mutableJson);
-    return notification;
+    mutableJson.remove('isRead');
+    return NotificationContent.fromJson(mutableJson);
   }
 
   factory NotificationContent.fromFirestore(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
     final mutableJson = Map<String, dynamic>.from(data);
-    mutableJson['isRead'] = false;
     mutableJson['savedAt'] = DateTime.now();
     mutableJson['id'] = doc.id;
-    final notification = NotificationContent.fromJson(mutableJson);
-    return notification;
-  }
-
-  Map<String, dynamic> toSQLite() {
-    final json = toJson();
-    json['isRead'] = json['isRead'] ? 1 : 0;
-    return json;
+    return NotificationContent.fromJson(mutableJson);
   }
 }
 

--- a/lib/features/notification/domain/models/notification_content.freezed.dart
+++ b/lib/features/notification/domain/models/notification_content.freezed.dart
@@ -24,7 +24,6 @@ mixin _$NotificationContent {
   DateTime get sendAt;
   @DateTimeConverter()
   DateTime get savedAt;
-  bool get isRead;
 
   /// Create a copy of NotificationContent
   /// with the given fields replaced by the non-null parameter values.
@@ -50,18 +49,17 @@ mixin _$NotificationContent {
             (identical(other.contents, contents) ||
                 other.contents == contents) &&
             (identical(other.sendAt, sendAt) || other.sendAt == sendAt) &&
-            (identical(other.savedAt, savedAt) || other.savedAt == savedAt) &&
-            (identical(other.isRead, isRead) || other.isRead == isRead));
+            (identical(other.savedAt, savedAt) || other.savedAt == savedAt));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, id, type, headerImagePath, title,
-      contents, sendAt, savedAt, isRead);
+  int get hashCode => Object.hash(
+      runtimeType, id, type, headerImagePath, title, contents, sendAt, savedAt);
 
   @override
   String toString() {
-    return 'NotificationContent(id: $id, type: $type, headerImagePath: $headerImagePath, title: $title, contents: $contents, sendAt: $sendAt, savedAt: $savedAt, isRead: $isRead)';
+    return 'NotificationContent(id: $id, type: $type, headerImagePath: $headerImagePath, title: $title, contents: $contents, sendAt: $sendAt, savedAt: $savedAt)';
   }
 }
 
@@ -78,8 +76,7 @@ abstract mixin class $NotificationContentCopyWith<$Res> {
       String title,
       String contents,
       @DateTimeConverter() DateTime sendAt,
-      @DateTimeConverter() DateTime savedAt,
-      bool isRead});
+      @DateTimeConverter() DateTime savedAt});
 }
 
 /// @nodoc
@@ -102,7 +99,6 @@ class _$NotificationContentCopyWithImpl<$Res>
     Object? contents = null,
     Object? sendAt = null,
     Object? savedAt = null,
-    Object? isRead = null,
   }) {
     return _then(_self.copyWith(
       id: null == id
@@ -133,10 +129,6 @@ class _$NotificationContentCopyWithImpl<$Res>
           ? _self.savedAt
           : savedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      isRead: null == isRead
-          ? _self.isRead
-          : isRead // ignore: cast_nullable_to_non_nullable
-              as bool,
     ));
   }
 }
@@ -241,23 +233,15 @@ extension NotificationContentPatterns on NotificationContent {
             String title,
             String contents,
             @DateTimeConverter() DateTime sendAt,
-            @DateTimeConverter() DateTime savedAt,
-            bool isRead)?
+            @DateTimeConverter() DateTime savedAt)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _NotificationContent() when $default != null:
-        return $default(
-            _that.id,
-            _that.type,
-            _that.headerImagePath,
-            _that.title,
-            _that.contents,
-            _that.sendAt,
-            _that.savedAt,
-            _that.isRead);
+        return $default(_that.id, _that.type, _that.headerImagePath,
+            _that.title, _that.contents, _that.sendAt, _that.savedAt);
       case _:
         return orElse();
     }
@@ -285,22 +269,14 @@ extension NotificationContentPatterns on NotificationContent {
             String title,
             String contents,
             @DateTimeConverter() DateTime sendAt,
-            @DateTimeConverter() DateTime savedAt,
-            bool isRead)
+            @DateTimeConverter() DateTime savedAt)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _NotificationContent():
-        return $default(
-            _that.id,
-            _that.type,
-            _that.headerImagePath,
-            _that.title,
-            _that.contents,
-            _that.sendAt,
-            _that.savedAt,
-            _that.isRead);
+        return $default(_that.id, _that.type, _that.headerImagePath,
+            _that.title, _that.contents, _that.sendAt, _that.savedAt);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -327,22 +303,14 @@ extension NotificationContentPatterns on NotificationContent {
             String title,
             String contents,
             @DateTimeConverter() DateTime sendAt,
-            @DateTimeConverter() DateTime savedAt,
-            bool isRead)?
+            @DateTimeConverter() DateTime savedAt)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _NotificationContent() when $default != null:
-        return $default(
-            _that.id,
-            _that.type,
-            _that.headerImagePath,
-            _that.title,
-            _that.contents,
-            _that.sendAt,
-            _that.savedAt,
-            _that.isRead);
+        return $default(_that.id, _that.type, _that.headerImagePath,
+            _that.title, _that.contents, _that.sendAt, _that.savedAt);
       case _:
         return null;
     }
@@ -359,8 +327,7 @@ class _NotificationContent extends NotificationContent {
       required this.title,
       required this.contents,
       @DateTimeConverter() required this.sendAt,
-      @DateTimeConverter() required this.savedAt,
-      required this.isRead})
+      @DateTimeConverter() required this.savedAt})
       : super._();
   factory _NotificationContent.fromJson(Map<String, dynamic> json) =>
       _$NotificationContentFromJson(json);
@@ -384,8 +351,6 @@ class _NotificationContent extends NotificationContent {
   @override
   @DateTimeConverter()
   final DateTime savedAt;
-  @override
-  final bool isRead;
 
   /// Create a copy of NotificationContent
   /// with the given fields replaced by the non-null parameter values.
@@ -416,18 +381,17 @@ class _NotificationContent extends NotificationContent {
             (identical(other.contents, contents) ||
                 other.contents == contents) &&
             (identical(other.sendAt, sendAt) || other.sendAt == sendAt) &&
-            (identical(other.savedAt, savedAt) || other.savedAt == savedAt) &&
-            (identical(other.isRead, isRead) || other.isRead == isRead));
+            (identical(other.savedAt, savedAt) || other.savedAt == savedAt));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, id, type, headerImagePath, title,
-      contents, sendAt, savedAt, isRead);
+  int get hashCode => Object.hash(
+      runtimeType, id, type, headerImagePath, title, contents, sendAt, savedAt);
 
   @override
   String toString() {
-    return 'NotificationContent(id: $id, type: $type, headerImagePath: $headerImagePath, title: $title, contents: $contents, sendAt: $sendAt, savedAt: $savedAt, isRead: $isRead)';
+    return 'NotificationContent(id: $id, type: $type, headerImagePath: $headerImagePath, title: $title, contents: $contents, sendAt: $sendAt, savedAt: $savedAt)';
   }
 }
 
@@ -446,8 +410,7 @@ abstract mixin class _$NotificationContentCopyWith<$Res>
       String title,
       String contents,
       @DateTimeConverter() DateTime sendAt,
-      @DateTimeConverter() DateTime savedAt,
-      bool isRead});
+      @DateTimeConverter() DateTime savedAt});
 }
 
 /// @nodoc
@@ -470,7 +433,6 @@ class __$NotificationContentCopyWithImpl<$Res>
     Object? contents = null,
     Object? sendAt = null,
     Object? savedAt = null,
-    Object? isRead = null,
   }) {
     return _then(_NotificationContent(
       id: null == id
@@ -501,10 +463,6 @@ class __$NotificationContentCopyWithImpl<$Res>
           ? _self.savedAt
           : savedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      isRead: null == isRead
-          ? _self.isRead
-          : isRead // ignore: cast_nullable_to_non_nullable
-              as bool,
     ));
   }
 }

--- a/lib/features/notification/domain/models/notification_content.g.dart
+++ b/lib/features/notification/domain/models/notification_content.g.dart
@@ -16,7 +16,6 @@ _NotificationContent _$NotificationContentFromJson(Map<String, dynamic> json) =>
       contents: json['contents'] as String,
       sendAt: const DateTimeConverter().fromJson(json['sendAt'] as String),
       savedAt: const DateTimeConverter().fromJson(json['savedAt'] as String),
-      isRead: json['isRead'] as bool,
     );
 
 Map<String, dynamic> _$NotificationContentToJson(
@@ -29,5 +28,4 @@ Map<String, dynamic> _$NotificationContentToJson(
       'contents': instance.contents,
       'sendAt': const DateTimeConverter().toJson(instance.sendAt),
       'savedAt': const DateTimeConverter().toJson(instance.savedAt),
-      'isRead': instance.isRead,
     };

--- a/lib/features/notification/domain/repositories/notification_repository.dart
+++ b/lib/features/notification/domain/repositories/notification_repository.dart
@@ -2,5 +2,4 @@ import 'package:kenryo_tankyu/features/notification/domain/models/notification_c
 
 abstract class NotificationRepository {
   Future<List<NotificationContent>> fetchNotifications();
-  Future<void> markAsRead(int id);
 }

--- a/lib/features/notification/presentation/providers/notification_provider.dart
+++ b/lib/features/notification/presentation/providers/notification_provider.dart
@@ -1,7 +1,8 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
 import 'package:kenryo_tankyu/features/notification/data/repositories/notification_repository_impl.dart';
 import 'package:kenryo_tankyu/features/notification/domain/models/notification_content.dart';
+import 'package:kenryo_tankyu/features/notification/presentation/providers/read_notification_ids_provider.dart';
 import 'package:kenryo_tankyu/core/connectivity/connectivity_provider.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
 
@@ -9,7 +10,6 @@ class NotificationNotifier
     extends Notifier<AsyncValue<List<NotificationContent>>> {
   @override
   AsyncValue<List<NotificationContent>> build() {
-    // 接続状態を監視し、回復時に再取得
     ref.listen(isConnectedProvider, (previous, next) {
       if (previous == false && next == true) {
         refresh();
@@ -37,39 +37,14 @@ class NotificationNotifier
     }
   }
 
-  Future<bool> markAsRead(int id) async {
-    try {
-      final repository = ref.read(notificationRepositoryProvider);
-      await repository.markAsRead(id);
+  Future<void> markAsReadAll() async {
+    final user = ref.read(authStateChangesProvider).asData?.value;
+    if (user == null) return;
 
-      state.whenData((notifications) {
-        state = AsyncValue.data(notifications.map((notification) {
-          if (notification.id == id.toString()) {
-            return notification.copyWith(isRead: true);
-          }
-          return notification;
-        }).toList());
-      });
-      return true;
-    } catch (e) {
-      // エラーログ出力などを行い、上位には成功/失敗を返すのみにする
-      debugPrint('markAsRead error: $e');
-      return false;
-    }
-  }
-
-  Future<bool> markAsReadAll() async {
-    try {
-      // TODO: リポジトリに指定がない場合は全件更新を検討
-      // 現状は state にあるものをすべて true にする
-      state.whenData((notifications) {
-        state = AsyncValue.data(
-            notifications.map((n) => n.copyWith(isRead: true)).toList());
-      });
-      return true;
-    } catch (e) {
-      return false;
-    }
+    final allIds = state.asData?.value.map((n) => n.id).toSet() ?? {};
+    await ref
+        .read(readNotificationIdsProvider.notifier)
+        .markAllAsRead(user.uid, allIds);
   }
 
   Future<void> refresh() async {

--- a/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
+++ b/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:kenryo_tankyu/core/providers/supabase_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -7,28 +8,40 @@ part 'read_notification_ids_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 class ReadNotificationIds extends _$ReadNotificationIds {
+  String? _activeUserId;
+
   @override
   Set<String> build() => {};
 
   Future<void> initialize(String userId) async {
+    _activeUserId = userId;
     final supabase = ref.read(supabaseClientProvider);
     try {
       final rows = await supabase
           .from('notification_reads')
           .select('notification_id')
           .eq('user_id', userId);
-      state = rows.map<String>((r) => r['notification_id'] as String).toSet();
+      if (_activeUserId == userId) {
+        state = rows.map<String>((r) => r['notification_id'] as String).toSet();
+      }
     } catch (_) {
-      state = {};
+      if (_activeUserId == userId) {
+        state = {};
+      }
     }
   }
 
   Future<void> markAsRead(String userId, String notificationId) async {
     state = {...state, notificationId};
     unawaited(
-      ref.read(supabaseClientProvider).from('notification_reads').upsert(
-        {'user_id': userId, 'notification_id': notificationId},
-      ),
+      ref
+          .read(supabaseClientProvider)
+          .from('notification_reads')
+          .upsert({'user_id': userId, 'notification_id': notificationId})
+          .then((_) => null)
+          .catchError((Object e) {
+            debugPrint('notification_reads upsert error: $e');
+          }),
     );
   }
 
@@ -39,11 +52,18 @@ class ReadNotificationIds extends _$ReadNotificationIds {
     state = {...state, ...notificationIds};
     if (notificationIds.isEmpty) return;
     unawaited(
-      ref.read(supabaseClientProvider).from('notification_reads').upsert(
+      ref
+          .read(supabaseClientProvider)
+          .from('notification_reads')
+          .upsert(
             notificationIds
                 .map((id) => {'user_id': userId, 'notification_id': id})
                 .toList(),
-          ),
+          )
+          .then((_) => null)
+          .catchError((Object e) {
+        debugPrint('notification_reads bulk upsert error: $e');
+      }),
     );
   }
 }

--- a/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
+++ b/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:kenryo_tankyu/core/providers/supabase_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'read_notification_ids_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class ReadNotificationIds extends _$ReadNotificationIds {
+  @override
+  Set<String> build() => {};
+
+  Future<void> initialize(String userId) async {
+    final supabase = ref.read(supabaseClientProvider);
+    try {
+      final rows = await supabase
+          .from('notification_reads')
+          .select('notification_id')
+          .eq('user_id', userId);
+      state = rows.map<String>((r) => r['notification_id'] as String).toSet();
+    } catch (_) {
+      state = {};
+    }
+  }
+
+  Future<void> markAsRead(String userId, String notificationId) async {
+    state = {...state, notificationId};
+    unawaited(
+      ref.read(supabaseClientProvider).from('notification_reads').upsert(
+        {'user_id': userId, 'notification_id': notificationId},
+      ),
+    );
+  }
+
+  Future<void> markAllAsRead(
+    String userId,
+    Set<String> notificationIds,
+  ) async {
+    state = {...state, ...notificationIds};
+    if (notificationIds.isEmpty) return;
+    unawaited(
+      ref.read(supabaseClientProvider).from('notification_reads').upsert(
+            notificationIds
+                .map((id) => {'user_id': userId, 'notification_id': id})
+                .toList(),
+          ),
+    );
+  }
+}

--- a/lib/features/notification/presentation/providers/read_notification_ids_provider.g.dart
+++ b/lib/features/notification/presentation/providers/read_notification_ids_provider.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'read_notification_ids_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ReadNotificationIds)
+const readNotificationIdsProvider = ReadNotificationIdsProvider._();
+
+final class ReadNotificationIdsProvider
+    extends $NotifierProvider<ReadNotificationIds, Set<String>> {
+  const ReadNotificationIdsProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'readNotificationIdsProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$readNotificationIdsHash();
+
+  @$internal
+  @override
+  ReadNotificationIds create() => ReadNotificationIds();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<String>>(value),
+    );
+  }
+}
+
+String _$readNotificationIdsHash() =>
+    r'5ebd09016feaeae549f851ff6cedf4a17c721a30';
+
+abstract class _$ReadNotificationIds extends $Notifier<Set<String>> {
+  Set<String> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<Set<String>, Set<String>>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<Set<String>, Set<String>>, Set<String>, Object?, Object?>;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/notification/presentation/widgets/notification_popup.dart
+++ b/lib/features/notification/presentation/widgets/notification_popup.dart
@@ -1,16 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
 import 'package:kenryo_tankyu/features/notification/domain/models/notification_content.dart';
+import 'package:kenryo_tankyu/features/notification/presentation/providers/read_notification_ids_provider.dart';
 import 'package:kenryo_tankyu/core/utils/text_with_url.dart';
 
-class NotificationPopup extends StatelessWidget {
+class NotificationPopup extends ConsumerStatefulWidget {
   final NotificationContent notification;
   const NotificationPopup({
-    Key? key,
+    super.key,
     required this.notification,
-  }) : super(key: key);
+  });
+
+  @override
+  ConsumerState<NotificationPopup> createState() => _NotificationPopupState();
+}
+
+class _NotificationPopupState extends ConsumerState<NotificationPopup> {
+  @override
+  void initState() {
+    super.initState();
+    _markAsRead();
+  }
+
+  void _markAsRead() {
+    final user = ref.read(authStateChangesProvider).asData?.value;
+    if (user == null) return;
+    ref
+        .read(readNotificationIdsProvider.notifier)
+        .markAsRead(user.uid, widget.notification.id);
+  }
 
   @override
   Widget build(BuildContext context) {
+    final readIds = ref.watch(readNotificationIdsProvider);
+    final isRead = readIds.contains(widget.notification.id);
+
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: Center(
@@ -25,7 +50,7 @@ class NotificationPopup extends StatelessWidget {
               BoxShadow(
                 color: Colors.black.withValues(alpha: 0.2),
                 blurRadius: 10,
-                offset: Offset(0, 4),
+                offset: const Offset(0, 4),
               ),
             ],
           ),
@@ -42,7 +67,7 @@ class NotificationPopup extends StatelessWidget {
                           Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
-                              notification.isRead
+                              isRead
                                   ? const SizedBox.shrink()
                                   : Text(
                                       'NEW',
@@ -77,12 +102,12 @@ class NotificationPopup extends StatelessWidget {
                           Row(
                             children: [
                               Icon(
-                                notification.type.icon,
+                                widget.notification.type.icon,
                                 color: Theme.of(context).colorScheme.primary,
                               ),
                               const SizedBox(width: 8),
                               Text(
-                                notification.title,
+                                widget.notification.title,
                                 style: const TextStyle(
                                   fontSize: 20,
                                   fontWeight: FontWeight.bold,
@@ -92,15 +117,14 @@ class NotificationPopup extends StatelessWidget {
                           ),
                           const SizedBox(height: 8),
                           Text(
-                            '${notification.sendAt.month}/${notification.sendAt.day} ${notification.sendAt.hour}:${notification.sendAt.minute.toString().padLeft(2, '0')}',
-                            style: TextStyle(
+                            '${widget.notification.sendAt.month}/${widget.notification.sendAt.day} ${widget.notification.sendAt.hour}:${widget.notification.sendAt.minute.toString().padLeft(2, '0')}',
+                            style: const TextStyle(
                               color: Colors.grey,
                               fontSize: 12,
                             ),
                           ),
                           const SizedBox(height: 16),
-                          TextWithUrl(
-                              text: notification.contents), // text:取得した文字列
+                          TextWithUrl(text: widget.notification.contents),
                         ],
                       ),
                     ),

--- a/lib/features/notification/presentation/widgets/notification_popup.dart
+++ b/lib/features/notification/presentation/widgets/notification_popup.dart
@@ -20,7 +20,9 @@ class _NotificationPopupState extends ConsumerState<NotificationPopup> {
   @override
   void initState() {
     super.initState();
-    _markAsRead();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _markAsRead();
+    });
   }
 
   void _markAsRead() {

--- a/lib/features/search/presentation/providers/search_history_provider.g.dart
+++ b/lib/features/search/presentation/providers/search_history_provider.g.dart
@@ -34,7 +34,7 @@ final class SearchHistoryCacheProvider
 }
 
 String _$searchHistoryCacheHash() =>
-    r'5bf10a914eeff6caec88d2c7ea9f7fb8f3fc3b3e';
+    r'255fd3a7e018fbebd7df5d79fc3fd55290551337';
 
 abstract class _$SearchHistoryCache extends $AsyncNotifier<List<Search>?> {
   FutureOr<List<Search>?> build();

--- a/lib/test/input_test_data_to_firestore.dart
+++ b/lib/test/input_test_data_to_firestore.dart
@@ -10,7 +10,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容1',
     sendAt: DateTime.now().subtract(Duration(days: 1)),
     savedAt: DateTime.now().subtract(Duration(days: 1)),
-    isRead: false,
     type: NotificationType.system,
   ),
   NotificationContent(
@@ -20,7 +19,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容2',
     sendAt: DateTime.now().subtract(Duration(days: 2)),
     savedAt: DateTime.now().subtract(Duration(days: 2)),
-    isRead: true,
     type: NotificationType.system,
   ),
   NotificationContent(
@@ -30,7 +28,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容3',
     sendAt: DateTime.now().subtract(Duration(days: 3)),
     savedAt: DateTime.now().subtract(Duration(days: 3)),
-    isRead: false,
     type: NotificationType.info,
   ),
   NotificationContent(
@@ -40,7 +37,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容4',
     sendAt: DateTime.now().subtract(Duration(days: 4)),
     savedAt: DateTime.now().subtract(Duration(days: 4)),
-    isRead: true,
     type: NotificationType.warning,
   ),
   NotificationContent(
@@ -50,7 +46,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容5',
     sendAt: DateTime.now().subtract(Duration(days: 5)),
     savedAt: DateTime.now().subtract(Duration(days: 5)),
-    isRead: false,
     type: NotificationType.system,
   ),
   NotificationContent(
@@ -60,7 +55,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容6',
     sendAt: DateTime.now().subtract(Duration(days: 6)),
     savedAt: DateTime.now().subtract(Duration(days: 6)),
-    isRead: true,
     type: NotificationType.info,
   ),
   NotificationContent(
@@ -70,7 +64,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容7',
     sendAt: DateTime.now().subtract(Duration(days: 7)),
     savedAt: DateTime.now().subtract(Duration(days: 7)),
-    isRead: false,
     type: NotificationType.warning,
   ),
   NotificationContent(
@@ -80,7 +73,6 @@ List<NotificationContent> testNotifications = [
     contents: '内容8',
     sendAt: DateTime.now().subtract(Duration(days: 8)),
     savedAt: DateTime.now().subtract(Duration(days: 8)),
-    isRead: true,
     type: NotificationType.system,
   ),
 ];
@@ -91,7 +83,6 @@ class FirestoreUpload {
     for (final notification in notifications) {
       //保存しないフィールドを削除
       final json = notification.toJson();
-      json.remove('isRead');
       json.remove('savedAt');
       json.remove('id');
       //sendAtをtimestampに変換

--- a/lib/test/test_value.dart
+++ b/lib/test/test_value.dart
@@ -8,6 +8,5 @@ final NotificationContent testNotificationValue = NotificationContent(
       '遂にβ版がリリースされました！\n2021年度入学生の探究作品の「キーワード検索」「カテゴリ検索」「お気に入り登録」などが使えるほか、縣陵先生図鑑も公開しています！\n\nバグや要望は以下のリンクからお知らせください！\nhttps://forms.gle/xUXX88MJ5fLsVtAk9',
   sendAt: DateTime(2025, 1, 3, 10, 0),
   savedAt: DateTime(2025, 1, 3, 10, 0),
-  isRead: false,
   type: NotificationType.update,
 );


### PR DESCRIPTION
## 概要
セッション⑤: 通知既読状態のSupabase移行。通知コンテンツはFirestore→SQLiteキャッシュの構成を維持しつつ、isRead状態だけをSupabaseの`notification_reads`テーブルで端末間同期できるようにする。

## 種別
- [x] 機能追加

## 関連Issue
Closes #  

## 変更内容
- `ReadNotificationIds` Riverpod Provider を新規追加（`keepAlive: true`）
  - `initialize(userId)`: ログイン時にSupabaseから既読ID一覧を取得してキャッシュ
  - `markAsRead(userId, notificationId)`: 楽観的UI更新 + Supabaseへ非同期upsert
  - `markAllAsRead(userId, notificationIds)`: 全件一括既読（`notification_page`の全既読ボタン用）
- `NotificationContent` モデルから `isRead` フィールドを削除（Supabaseキャッシュで代替）
- `notification_db.dart` をバージョン3→4に更新
  - `onUpgrade`でnotificationテーブルを再作成し`isRead`列を除去
  - `markAsRead` / `markAsReadAll` メソッドを削除
- `NotificationLocalDataSource` / `NotificationRepository` / `NotificationRepositoryImpl` から `markAsRead` を削除
- `NotificationNotifier` を更新: `markAsRead` 削除・`markAsReadAll` を `ReadNotificationIds` 経由に変更
- `notification_popup.dart` を `ConsumerStatefulWidget` に変更
  - ポップアップ表示時に `markAsRead` を自動呼び出し
  - `isRead` 判定を `ReadNotificationIds` キャッシュから行うよう変更
- `auth_provider.dart`: ログイン確定時に `ReadNotificationIds.initialize()` を呼び出し、ログアウト時に `invalidate`
- テストファイル（`test_value.dart` / `input_test_data_to_firestore.dart`）から `isRead` 参照を削除

## 事前作業（Supabaseコンソール）
以下のSQLでテーブルを作成する必要があります：
```sql
CREATE TABLE notification_reads (
  user_id         TEXT        NOT NULL,
  notification_id TEXT        NOT NULL,
  read_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  PRIMARY KEY (user_id, notification_id)
);
CREATE INDEX idx_notification_reads_user_id ON notification_reads(user_id);
```

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）