### PR TITLE
[Bug] #158 アカウント削除時のSupabaseデータ残存・#159 キャッシュヒット時のviewed_at未更新 を修正

### DIFF
--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -4,6 +4,7 @@ import "package:kenryo_tankyu/core/constants/feature/user_value.dart";
 import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_repository_provider.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/providers/user_repository_provider.dart';
 import 'package:kenryo_tankyu/features/auth/domain/models/auth.dart';
+import 'package:kenryo_tankyu/core/providers/supabase_provider.dart';
 import 'package:kenryo_tankyu/features/notification/data/datasources/notification_db.dart';
 import 'package:kenryo_tankyu/features/notification/presentation/providers/read_notification_ids_provider.dart';
 import 'package:kenryo_tankyu/features/search/data/datasources/search_history_data_source.dart';
@@ -13,6 +14,7 @@ import 'package:kenryo_tankyu/features/user_archive/data/datasources/favorites_r
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' show SupabaseClient;
 
 part 'auth_provider.g.dart';
 
@@ -133,7 +135,9 @@ class AuthNotifier extends _$AuthNotifier {
     final searchHistoryDs = ref.read(searchHistoryDataSourceProvider);
     final browsingHistoryDs = ref.read(browsingHistoryDataSourceProvider);
     final favoritesDs = ref.read(favoritesRemoteDataSourceProvider);
-    final readNotifIds = ref.read(readNotificationIdsProvider.notifier);
+    // readNotificationIdsProvider は deleteUser() 後に invalidate・dispose されるため、
+    // Notifier 経由ではなく SupabaseClient を直接退避して削除する。
+    final supabaseClient = ref.read(supabaseClientProvider);
 
     final user = authRepo.currentUser;
     if (user == null || user.email == null) return;
@@ -157,7 +161,7 @@ class AuthNotifier extends _$AuthNotifier {
       searchHistoryDs: searchHistoryDs,
       browsingHistoryDs: browsingHistoryDs,
       favoritesDs: favoritesDs,
-      readNotifIds: readNotifIds,
+      supabaseClient: supabaseClient,
     );
   }
 
@@ -167,7 +171,7 @@ class AuthNotifier extends _$AuthNotifier {
     required SearchHistoryDataSource searchHistoryDs,
     required BrowsingHistoryDataSource browsingHistoryDs,
     required FavoritesRemoteDataSource favoritesDs,
-    required ReadNotificationIds readNotifIds,
+    required SupabaseClient supabaseClient,
   }) async {
     try {
       await pdfDs.deleteAllPdf();
@@ -182,7 +186,10 @@ class AuthNotifier extends _$AuthNotifier {
       await favoritesDs.deleteAllFavorites(userId);
     } catch (_) {}
     try {
-      await readNotifIds.deleteAll(userId);
+      await supabaseClient
+          .from('notification_reads')
+          .delete()
+          .eq('user_id', userId);
     } catch (_) {}
     try {
       await NotificationDbController.deleteAllNotifications();

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -8,6 +8,8 @@ import 'package:kenryo_tankyu/features/notification/data/datasources/notificatio
 import 'package:kenryo_tankyu/features/notification/presentation/providers/read_notification_ids_provider.dart';
 import 'package:kenryo_tankyu/features/search/data/datasources/search_history_data_source.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_provider.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/browsing_history_data_source.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/favorites_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -129,6 +131,9 @@ class AuthNotifier extends _$AuthNotifier {
     // ref.readで取得するデータソースは非同期処理の前にすべて退避しておく。
     final pdfDs = ref.read(pdfLocalDataSourceProvider);
     final searchHistoryDs = ref.read(searchHistoryDataSourceProvider);
+    final browsingHistoryDs = ref.read(browsingHistoryDataSourceProvider);
+    final favoritesDs = ref.read(favoritesRemoteDataSourceProvider);
+    final readNotifIds = ref.read(readNotificationIdsProvider.notifier);
 
     final user = authRepo.currentUser;
     if (user == null || user.email == null) return;
@@ -150,6 +155,9 @@ class AuthNotifier extends _$AuthNotifier {
       userId: user.uid,
       pdfDs: pdfDs,
       searchHistoryDs: searchHistoryDs,
+      browsingHistoryDs: browsingHistoryDs,
+      favoritesDs: favoritesDs,
+      readNotifIds: readNotifIds,
     );
   }
 
@@ -157,12 +165,24 @@ class AuthNotifier extends _$AuthNotifier {
     required String userId,
     required PdfLocalDataSource pdfDs,
     required SearchHistoryDataSource searchHistoryDs,
+    required BrowsingHistoryDataSource browsingHistoryDs,
+    required FavoritesRemoteDataSource favoritesDs,
+    required ReadNotificationIds readNotifIds,
   }) async {
     try {
       await pdfDs.deleteAllPdf();
     } catch (_) {}
     try {
       await searchHistoryDs.deleteAllHistory(userId);
+    } catch (_) {}
+    try {
+      await browsingHistoryDs.deleteAllHistory(userId);
+    } catch (_) {}
+    try {
+      await favoritesDs.deleteAllFavorites(userId);
+    } catch (_) {}
+    try {
+      await readNotifIds.deleteAll(userId);
     } catch (_) {}
     try {
       await NotificationDbController.deleteAllNotifications();

--- a/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
+++ b/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
@@ -66,12 +66,4 @@ class ReadNotificationIds extends _$ReadNotificationIds {
       }),
     );
   }
-
-  Future<void> deleteAll(String userId) async {
-    await ref
-        .read(supabaseClientProvider)
-        .from('notification_reads')
-        .delete()
-        .eq('user_id', userId);
-  }
 }

--- a/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
+++ b/lib/features/notification/presentation/providers/read_notification_ids_provider.dart
@@ -66,4 +66,12 @@ class ReadNotificationIds extends _$ReadNotificationIds {
       }),
     );
   }
+
+  Future<void> deleteAll(String userId) async {
+    await ref
+        .read(supabaseClientProvider)
+        .from('notification_reads')
+        .delete()
+        .eq('user_id', userId);
+  }
 }

--- a/lib/features/research_work/presentation/providers/searched_provider.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.dart
@@ -43,7 +43,8 @@ class ResearchWork extends _$ResearchWork {
       final cached = await archiveRepo.getHistory(documentID);
       if (cached != null) {
         result = cached.copyWith(isCached: false);
-        unawaited(archiveRepo.updateHistoryViewedAt(documentID));
+        unawaited(
+            archiveRepo.updateHistoryViewedAt(documentID).catchError((_) {}));
       } else {
         result = await fetchFromServer();
       }

--- a/lib/features/research_work/presentation/providers/searched_provider.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.dart
@@ -43,6 +43,7 @@ class ResearchWork extends _$ResearchWork {
       final cached = await archiveRepo.getHistory(documentID);
       if (cached != null) {
         result = cached.copyWith(isCached: false);
+        unawaited(archiveRepo.updateHistoryViewedAt(documentID));
       } else {
         result = await fetchFromServer();
       }

--- a/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
+++ b/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
@@ -104,6 +104,15 @@ class BrowsingHistoryDataSource {
     return (count: dates.length, oldest: dates.first, newest: dates.last);
   }
 
+  /// キャッシュヒット時に viewed_at のみ更新（帯域節約）
+  Future<void> updateViewedAt(String userId, int documentId) async {
+    await _client
+        .from('browsing_history')
+        .update({'viewed_at': DateTime.now().toUtc().toIso8601String()})
+        .eq('user_id', userId)
+        .eq('document_id', documentId);
+  }
+
   /// お気に入り操作に伴う likes の差分更新（現在値を取得してから +delta）
   Future<void> updateLikes(String userId, int documentID, int delta) async {
     final row = await _client

--- a/lib/features/user_archive/data/datasources/favorites_remote_data_source.dart
+++ b/lib/features/user_archive/data/datasources/favorites_remote_data_source.dart
@@ -46,4 +46,8 @@ class FavoritesRemoteDataSource {
         .maybeSingle();
     return row != null;
   }
+
+  Future<void> deleteAllFavorites(String userId) async {
+    await _client.from('favorites').delete().eq('user_id', userId);
+  }
 }

--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -143,6 +143,17 @@ class UserArchiveRepositoryImpl
   }
 
   @override
+  Future<void> updateHistoryViewedAt(int documentID) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
+    try {
+      await _browsingHistoryDataSource.updateViewedAt(userId, documentID);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
   Future<void> changeFavoriteState(int documentID, bool nextIsFavorite) async {
     final userId = FirebaseAuth.instance.currentUser?.uid;
     if (userId == null) throw mapException(Exception('ログインしていません'));

--- a/lib/features/user_archive/domain/repositories/user_archive_repository.dart
+++ b/lib/features/user_archive/domain/repositories/user_archive_repository.dart
@@ -15,6 +15,7 @@ abstract class UserArchiveRepository {
   Future<HistoryStats> getHistoryStats();
   Future<List<DateTime>> getAllHistorySavedDates();
   Future<void> updateHistoryWork(int documentID, Searched latest);
+  Future<void> updateHistoryViewedAt(int documentID);
 
   // Favorite (combines local DB and potentially remote updates)
   Future<void> changeFavoriteState(int documentID, bool nextIsFavorite);


### PR DESCRIPTION
## 概要

SQLite→Supabase移行後に発覚した2つのバグを修正する。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #158
Closes #159

## 変更内容

### #158: アカウント削除時にSupabaseのユーザーデータが残存する

`_clearAllLocalData()` では `search_history` と PDF キャッシュしか削除されておらず、`browsing_history` / `favorites` / `notification_reads` の3テーブルにデータが残っていた。

- `FavoritesRemoteDataSource` に `deleteAllFavorites(userId)` を追加
- `ReadNotificationIds` に `deleteAll(userId)` を追加
- `auth_provider.dart` の `deleteAccount()` でこれら3つの DataSource / Notifier をAuth削除前に退避
- `_clearAllLocalData()` で全テーブルの削除を実行するよう修正

### #159: キャッシュヒット時に `viewed_at` が更新されず履歴順が狂う

`searched_provider.dart` のキャッシュヒット分岐で `insertHistory()` が呼ばれておらず、同じ作品を繰り返し開いても `viewed_at` が最初に開いた日時のままになっていた。

方針（帯域節約）:
- `fetchFromServer()` 経由（初回 or 強制リロード）→ 全フィールド upsert（既存動作を維持）
- キャッシュヒット（2回目以降）→ `viewed_at` のみ UPDATE

対応:
- `BrowsingHistoryDataSource` に `updateViewedAt(userId, documentId)` を追加
- `UserArchiveRepository` インターフェースと impl に `updateHistoryViewedAt(documentID)` を追加
- キャッシュヒット時に `unawaited(archiveRepo.updateHistoryViewedAt(documentID))` を呼ぶよう修正

## スクリーンショット

なし（ロジック修正のみ）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし（`flutter analyze` / `dart format` 確認済み）
- [ ] テストを追加または更新済み（必要な場合）