### PR TITLE
[Bug] #160 #161 #162 履歴削除・FavoriteIdsCache・refreshIfStale のバグ修正

### DIFF
--- a/document/supabase_rpc_delete_history_with_favorite.sql
+++ b/document/supabase_rpc_delete_history_with_favorite.sql
@@ -1,0 +1,21 @@
+-- #160 対応: browsing_history と favorites を原子的に削除する RPC 関数
+-- Supabase の SQL Editor で実行してください。
+--
+-- 用途: 閲覧履歴の個別削除時に、そのアイテムがお気に入りに登録されている場合も
+--       favorites テーブルから同時に削除するトランザクションを提供します。
+
+CREATE OR REPLACE FUNCTION delete_history_with_favorite(
+  p_user_id     TEXT,
+  p_document_id INTEGER
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  DELETE FROM browsing_history
+    WHERE user_id = p_user_id AND document_id = p_document_id;
+
+  DELETE FROM favorites
+    WHERE user_id = p_user_id AND document_id = p_document_id;
+END;
+$$;

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -12,7 +12,6 @@ import 'package:kenryo_tankyu/features/search/presentation/providers/search_hist
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/browsing_history_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/favorites_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/pdf_local_data_source.dart';
-import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' show SupabaseClient;
 
@@ -33,9 +32,7 @@ class AuthNotifier extends _$AuthNotifier {
       (_, next) {
         next.whenData((user) {
           if (user != null && user.emailVerified) {
-            unawaited(
-              ref.read(favoriteIdsCacheProvider.notifier).initialize(user.uid),
-            );
+            // FavoriteIdsCache は authStateChangesProvider を watch して自己初期化するため不要
             unawaited(
               ref.read(searchHistoryCacheProvider.notifier).initialize(),
             );
@@ -45,7 +42,7 @@ class AuthNotifier extends _$AuthNotifier {
                   .initialize(user.uid),
             );
           } else {
-            ref.invalidate(favoriteIdsCacheProvider);
+            // FavoriteIdsCache は authStateChangesProvider を watch して自動リセットするため不要
             ref.invalidate(searchHistoryCacheProvider);
             ref.invalidate(readNotificationIdsProvider);
           }

--- a/lib/features/auth/presentation/providers/auth_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.g.dart
@@ -73,7 +73,7 @@ final class AuthNotifierProvider extends $NotifierProvider<AuthNotifier, Auth> {
   }
 }
 
-String _$authNotifierHash() => r'6d01c67c64cea1181eba92b2cd2ffd8f45ee4246';
+String _$authNotifierHash() => r'833627c63f0f131408f4298cbf5537bca2f75ff3';
 
 abstract class _$AuthNotifier extends $Notifier<Auth> {
   Auth build();

--- a/lib/features/notification/presentation/providers/read_notification_ids_provider.g.dart
+++ b/lib/features/notification/presentation/providers/read_notification_ids_provider.g.dart
@@ -42,7 +42,7 @@ final class ReadNotificationIdsProvider
 }
 
 String _$readNotificationIdsHash() =>
-    r'5ebd09016feaeae549f851ff6cedf4a17c721a30';
+    r'9a635cb0fc2565620dd08207ffbbfec03904107a';
 
 abstract class _$ReadNotificationIds extends $Notifier<Set<String>> {
   Set<String> build();

--- a/lib/features/research_work/presentation/providers/searched_provider.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.dart
@@ -19,8 +19,11 @@ final forceReloadProvider = StateProvider.autoDispose<bool>((ref) => false);
 
 @riverpod
 class ResearchWork extends _$ResearchWork {
+  late int _documentID;
+
   @override
   Future<Searched> build(int documentID) async {
+    _documentID = documentID;
     final repository = ref.watch(researchWorkRepositoryProvider);
     final archiveRepo = ref.watch(userArchiveRepositoryProvider);
     final forceReload = ref.read(forceReloadProvider);
@@ -36,26 +39,17 @@ class ResearchWork extends _$ResearchWork {
       return combined;
     }
 
-    final Searched result;
     if (forceReload) {
-      result = await fetchFromServer();
-    } else {
-      final cached = await archiveRepo.getHistory(documentID);
-      if (cached != null) {
-        result = cached.copyWith(isCached: false);
-        unawaited(
-            archiveRepo.updateHistoryViewedAt(documentID).catchError((_) {}));
-      } else {
-        result = await fetchFromServer();
-      }
+      return await fetchFromServer();
     }
 
-    // キャッシュから取得した場合のみ陳腐化チェックを実施
-    if (result.savedAt != null) {
-      unawaited(_refreshLikesIfStale(documentID, result.savedAt!, result));
+    final cached = await archiveRepo.getHistory(documentID);
+    if (cached != null) {
+      unawaited(
+          archiveRepo.updateHistoryViewedAt(documentID).catchError((_) {}));
+      return cached.copyWith(isCached: false);
     }
-
-    return result;
+    return await fetchFromServer();
   }
 
   /// お気に入り操作後に UI を即時更新する（invalidate による再フェッチを使わない）
@@ -65,22 +59,26 @@ class ResearchWork extends _$ResearchWork {
     );
   }
 
-  Future<void> _refreshLikesIfStale(
-    int documentID,
-    DateTime viewedAt,
-    Searched current,
-  ) async {
+  /// UI 側から明示的に呼ぶ陳腐化チェック。state が AsyncData でない場合や
+  /// 90 日以内のキャッシュの場合は何もしない。
+  Future<void> refreshIfStale() async {
+    final data = state.asData?.value;
+    if (data?.savedAt == null) return;
+    final viewedAt = data!.savedAt!;
     if (DateTime.now().difference(viewedAt) < const Duration(days: 90)) return;
+    await _doRefresh(viewedAt, data);
+  }
 
+  Future<void> _doRefresh(DateTime viewedAt, Searched current) async {
     if (!ref.mounted) return;
-    ref.read(isRefreshingLikesProvider(documentID).notifier).set(true);
+    ref.read(isRefreshingLikesProvider(_documentID).notifier).set(true);
 
     try {
       final repository = ref.read(researchWorkRepositoryProvider);
       final archiveRepo = ref.read(userArchiveRepositoryProvider);
       final userId = FirebaseAuth.instance.currentUser?.uid;
 
-      final latest = await repository.getWork(documentID.toString());
+      final latest = await repository.getWork(_documentID.toString());
       final updated =
           latest.copyWith(isFavorite: current.isFavorite, isCached: false);
 
@@ -88,13 +86,13 @@ class ResearchWork extends _$ResearchWork {
       state = AsyncData(updated);
 
       if (userId != null) {
-        unawaited(archiveRepo.updateHistoryWork(documentID, updated));
+        unawaited(archiveRepo.updateHistoryWork(_documentID, updated));
       }
     } catch (_) {
       // バックグラウンド更新の失敗はサイレントに無視
     } finally {
       if (ref.mounted) {
-        ref.read(isRefreshingLikesProvider(documentID).notifier).set(false);
+        ref.read(isRefreshingLikesProvider(_documentID).notifier).set(false);
       }
     }
   }

--- a/lib/features/research_work/presentation/providers/searched_provider.g.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.g.dart
@@ -49,7 +49,7 @@ final class ResearchWorkProvider
   }
 }
 
-String _$researchWorkHash() => r'dec96d425254ca79b9454e8db6f869338eb267fb';
+String _$researchWorkHash() => r'796340f18356e701904ead3cfe7ff248ee9c7e75';
 
 final class ResearchWorkFamily extends $Family
     with

--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -23,6 +23,7 @@ class ResultPage extends ConsumerStatefulWidget {
 class _ResultPageMainState extends ConsumerState<ResultPage> {
   final ScreenCaptureEvent screenListener = ScreenCaptureEvent();
   ScaffoldMessengerState? _messenger;
+  ProviderSubscription<AsyncValue<Searched>>? _staleCheckSub;
 
   @override
   void initState() {
@@ -33,10 +34,30 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
     Future.delayed(Duration.zero, () {
       screenListener.watch();
     });
+
+    // listenManual + fireImmediately: true で、キャッシュ済みの場合も含めて
+    // loading → data 遷移を一度だけ検知して陳腐化チェックを実行する。
+    // WidgetRef.listen は fireImmediately 非対応のためここで登録する。
+    _staleCheckSub = ref.listenManual(
+      researchWorkProvider(widget.documentID),
+      (prev, next) {
+        if (prev?.hasValue != true && next.hasValue) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              ref
+                  .read(researchWorkProvider(widget.documentID).notifier)
+                  .refreshIfStale();
+            }
+          });
+        }
+      },
+      fireImmediately: true,
+    );
   }
 
   @override
   void dispose() {
+    _staleCheckSub?.close();
     _messenger?.clearSnackBars();
     screenListener.dispose();
     super.dispose();
@@ -58,19 +79,6 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
         );
       } else if (prev == true) {
         _messenger?.clearSnackBars();
-      }
-    });
-
-    // loading → data に変わった瞬間に一度だけ陳腐化チェックを実行
-    ref.listen(researchWorkProvider(widget.documentID), (prev, next) {
-      if (prev?.hasValue != true && next.hasValue) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            ref
-                .read(researchWorkProvider(widget.documentID).notifier)
-                .refreshIfStale();
-          }
-        });
       }
     });
 

--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -61,6 +61,19 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
       }
     });
 
+    // loading → data に変わった瞬間に一度だけ陳腐化チェックを実行
+    ref.listen(researchWorkProvider(widget.documentID), (prev, next) {
+      if (prev?.hasValue != true && next.hasValue) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            ref
+                .read(researchWorkProvider(widget.documentID).notifier)
+                .refreshIfStale();
+          }
+        });
+      }
+    });
+
     final currentIndex = ref.watch(isFullScreenProvider) ? 1 : 0; //全画面表示かどうか
     final AsyncValue<Searched> searched =
         ref.watch(searchedItemProvider(widget.documentID));

--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -126,6 +126,6 @@ SearchRepository searchRepository(Ref ref) {
   final dataSource = ref.watch(searchDataSourceProvider);
   return SearchRepositoryImpl(
     dataSource,
-    () => ref.read(favoriteIdsCacheProvider),
+    () => ref.read(favoriteIdsCacheProvider).asData?.value ?? {},
   );
 }

--- a/lib/features/search/presentation/widgets/result_preview_content.dart
+++ b/lib/features/search/presentation/widgets/result_preview_content.dart
@@ -29,7 +29,11 @@ class ResultPreviewContent extends ConsumerWidget {
                 builder: (context) {
                   return AlertDialog(
                     title: const Text('履歴を消去しますか？'),
-                    content: Text('「${searched.title}」の履歴を消去しますか？'),
+                    content: Text(
+                      searched.isFavorite
+                          ? '「${searched.title}」の履歴を消去しますか？\n\nこの作品はお気に入りに登録されています。消去すると、お気に入り状態も同時に解除されます。'
+                          : '「${searched.title}」の履歴を消去しますか？',
+                    ),
                     actions: [
                       TextButton(
                         onPressed: () {
@@ -41,7 +45,10 @@ class ResultPreviewContent extends ConsumerWidget {
                         onPressed: () async {
                           await ref
                               .read(historyControllerProvider.notifier)
-                              .deleteHistory(searched.documentID);
+                              .deleteHistory(
+                                searched.documentID,
+                                isFavorite: searched.isFavorite,
+                              );
                           if (context.mounted) {
                             Navigator.of(context).pop();
                           }

--- a/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
+++ b/lib/features/user_archive/data/datasources/browsing_history_data_source.dart
@@ -67,6 +67,16 @@ class BrowsingHistoryDataSource {
         .eq('document_id', documentID);
   }
 
+  /// browsing_history と favorites を Postgres トランザクションで原子的に削除する。
+  /// Supabase に delete_history_with_favorite RPC 関数が必要
+  /// (document/supabase_rpc_delete_history_with_favorite.sql を参照)。
+  Future<void> deleteHistoryAndFavorite(String userId, int documentId) async {
+    await _client.rpc('delete_history_with_favorite', params: {
+      'p_user_id': userId,
+      'p_document_id': documentId,
+    });
+  }
+
   Future<void> deleteAllHistory(String userId) async {
     await _client.from('browsing_history').delete().eq('user_id', userId);
   }

--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -87,6 +87,23 @@ class UserArchiveRepositoryImpl
   }
 
   @override
+  Future<void> deleteHistoryWithFavorite(int documentID) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
+    try {
+      // Postgres トランザクション（RPC）で browsing_history + favorites を原子的に削除
+      await _browsingHistoryDataSource.deleteHistoryAndFavorite(
+          userId, documentID);
+    } catch (e) {
+      throw mapException(e);
+    }
+    // Firestore の likes をデクリメント（失敗しても無視）
+    try {
+      await updateRemoteLikes(documentID, false);
+    } catch (_) {}
+  }
+
+  @override
   Future<void> deleteAllHistory() async {
     final userId = FirebaseAuth.instance.currentUser?.uid;
     if (userId == null) return;

--- a/lib/features/user_archive/domain/repositories/user_archive_repository.dart
+++ b/lib/features/user_archive/domain/repositories/user_archive_repository.dart
@@ -10,6 +10,7 @@ abstract class UserArchiveRepository {
   Future<void> insertHistory(Searched searched);
   Future<Searched?> getHistory(int documentID);
   Future<void> deleteHistory(int documentID);
+  Future<void> deleteHistoryWithFavorite(int documentID);
   Future<void> deleteAllHistory();
   Future<void> deleteHistoryBefore(DateTime date);
   Future<HistoryStats> getHistoryStats();

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -50,14 +50,22 @@ class FavoriteIdsCache extends _$FavoriteIdsCache {
         .getFavoriteIds(user.uid);
   }
 
-  void add(int id) {
-    final current = state.asData?.value ?? {};
-    state = AsyncData({...current, id});
+  Future<void> add(int id) async {
+    try {
+      final current = await future;
+      state = AsyncData({...current, id});
+    } catch (_) {
+      state = AsyncData({id});
+    }
   }
 
-  void remove(int id) {
-    final current = state.asData?.value ?? {};
-    state = AsyncData(current.difference({id}));
+  Future<void> remove(int id) async {
+    try {
+      final current = await future;
+      state = AsyncData(current.difference({id}));
+    } catch (_) {
+      state = const AsyncData({});
+    }
   }
 }
 

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
+import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/providers/searched_provider.dart';
 import 'package:kenryo_tankyu/features/user_archive/data/datasources/browsing_history_data_source.dart';
@@ -39,19 +40,25 @@ UserArchiveRepository userArchiveRepository(Ref ref) {
 @Riverpod(keepAlive: true)
 class FavoriteIdsCache extends _$FavoriteIdsCache {
   @override
-  Set<int> build() => {};
-
-  Future<void> initialize(String userId) async {
-    final dataSource = ref.read(favoritesRemoteDataSourceProvider);
-    try {
-      state = await dataSource.getFavoriteIds(userId);
-    } catch (_) {
-      state = {};
-    }
+  Future<Set<int>> build() async {
+    // auth ストリームの最初の値を待つ。
+    // ログイン/ログアウト時に authStateChangesProvider が変わると自動で再実行される。
+    final user = await ref.watch(authStateChangesProvider.future);
+    if (user == null || !user.emailVerified) return {};
+    return await ref
+        .read(favoritesRemoteDataSourceProvider)
+        .getFavoriteIds(user.uid);
   }
 
-  void add(int id) => state = {...state, id};
-  void remove(int id) => state = state.difference({id});
+  void add(int id) {
+    final current = state.asData?.value ?? {};
+    state = AsyncData({...current, id});
+  }
+
+  void remove(int id) {
+    final current = state.asData?.value ?? {};
+    state = AsyncData(current.difference({id}));
+  }
 }
 
 /// ボタン連打防止を管理するProvider
@@ -153,8 +160,9 @@ Future<List<Searched>?> searchedHistory(Ref ref, bool onlyShowFavorite) async {
   } else {
     final history = await repository.getAllHistory();
     if (history == null) return null;
-    // FavoriteIdsCache はインメモリキャッシュなので Supabase を叩かない
-    final favoriteIds = ref.read(favoriteIdsCacheProvider);
+    // FavoriteIdsCache の初期化完了を待ってから isFavorite を付与する。
+    // これにより初期化前に全件 unfavorited になる競合状態を防ぐ。
+    final favoriteIds = await ref.watch(favoriteIdsCacheProvider.future);
     return history
         .map((h) => h.copyWith(isFavorite: favoriteIds.contains(h.documentID)))
         .toList();
@@ -166,9 +174,15 @@ class HistoryController extends _$HistoryController {
   @override
   void build() {}
 
-  Future<void> deleteHistory(int id) async {
+  Future<void> deleteHistory(int id, {bool isFavorite = false}) async {
     final repository = ref.read(userArchiveRepositoryProvider);
-    await repository.deleteHistory(id);
+    if (isFavorite) {
+      await repository.deleteHistoryWithFavorite(id);
+      if (!ref.mounted) return;
+      ref.read(favoriteIdsCacheProvider.notifier).remove(id);
+    } else {
+      await repository.deleteHistory(id);
+    }
     if (!ref.mounted) return;
     ref.invalidate(searchedHistoryProvider);
   }

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
@@ -51,13 +51,13 @@ final class UserArchiveRepositoryProvider extends $FunctionalProvider<
 }
 
 String _$userArchiveRepositoryHash() =>
-    r'3144510063e2dec0a0491edf826b82ec6e79712e';
+    r'0cc9ca50197c441d2241527354e8fb97cf3d3d4f';
 
 @ProviderFor(FavoriteIdsCache)
 const favoriteIdsCacheProvider = FavoriteIdsCacheProvider._();
 
 final class FavoriteIdsCacheProvider
-    extends $NotifierProvider<FavoriteIdsCache, Set<int>> {
+    extends $AsyncNotifierProvider<FavoriteIdsCache, Set<int>> {
   const FavoriteIdsCacheProvider._()
       : super(
           from: null,
@@ -75,27 +75,22 @@ final class FavoriteIdsCacheProvider
   @$internal
   @override
   FavoriteIdsCache create() => FavoriteIdsCache();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Set<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<Set<int>>(value),
-    );
-  }
 }
 
-String _$favoriteIdsCacheHash() => r'601decced1c010a9a800c8bdc9a85aa7463d33e4';
+String _$favoriteIdsCacheHash() => r'6d9b76398c88e8734def2b30944d92564c8a068b';
 
-abstract class _$FavoriteIdsCache extends $Notifier<Set<int>> {
-  Set<int> build();
+abstract class _$FavoriteIdsCache extends $AsyncNotifier<Set<int>> {
+  FutureOr<Set<int>> build();
   @$mustCallSuper
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<Set<int>, Set<int>>;
+    final ref = this.ref as $Ref<AsyncValue<Set<int>>, Set<int>>;
     final element = ref.element as $ClassProviderElement<
-        AnyNotifier<Set<int>, Set<int>>, Set<int>, Object?, Object?>;
+        AnyNotifier<AsyncValue<Set<int>>, Set<int>>,
+        AsyncValue<Set<int>>,
+        Object?,
+        Object?>;
     element.handleValue(ref, created);
   }
 }
@@ -295,7 +290,7 @@ final class SearchedHistoryProvider extends $FunctionalProvider<
   }
 }
 
-String _$searchedHistoryHash() => r'f413d39021c6d21fe54b9e7ad1b1bbd826e1de71';
+String _$searchedHistoryHash() => r'73fc7538c5477eef98cc6742da99d5c74c9700af';
 
 final class SearchedHistoryFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<Searched>?>, bool> {
@@ -349,7 +344,7 @@ final class HistoryControllerProvider
   }
 }
 
-String _$historyControllerHash() => r'32a690092760aa7ca5bdf626dbbad41a4941b8d5';
+String _$historyControllerHash() => r'56f12497211c6200902c5cab557b7b0a7b0f6ee6';
 
 abstract class _$HistoryController extends $Notifier<void> {
   void build();


### PR DESCRIPTION
## 概要
SQLite→Supabase移行後のバグ #160, #161, #162 を修正する。

## 種別
- [x] バグ修正

## 関連Issue
Closes #160
Closes #161
Closes #162

## 変更内容

### #160: 履歴個別削除でお気に入りも消える問題
- 削除確認ダイアログにお気に入り登録中である旨の警告文を追加
- 削除時に `favorites` と `browsing_history` を Postgres トランザクション（RPC）で原子的に削除
- `BrowsingHistoryDataSource.deleteHistoryAndFavorite()` を追加（`delete_history_with_favorite` RPC 呼び出し）
- `UserArchiveRepository.deleteHistoryWithFavorite()` を追加（favorites 削除後に Firestore likes もデクリメント）
- `HistoryController.deleteHistory()` に `isFavorite` オプションを追加し、FavoriteIdsCache も更新
- RPC 関数の SQL を `document/supabase_rpc_delete_history_with_favorite.sql` に記載
  → **Supabase の SQL Editor でこの関数を実行してください**

### #161: 未初期化タイミングで全件 unfavorited 表示になる問題
- `FavoriteIdsCache` を `Notifier<Set<int>>` から `AsyncNotifier<Set<int>>` に変更
- `build()` で `authStateChangesProvider` を watch することで、ログイン時に自動初期化・ログアウト時に自動リセット
- `searchedHistory` で `ref.read` → `ref.watch(favoriteIdsCacheProvider.future)` に変更し、初期化完了を待ってから isFavorite を付与
- `AuthNotifier` から `initialize()`/`invalidate()` の明示的呼び出しを削除（自己管理化）

### #162: `build()` 内の unawaited(_refreshLikesIfStale) アンチパターン
- `ResearchWork.build()` から `unawaited(_refreshLikesIfStale(...))` を除去
- `refreshIfStale()` を公開メソッドとして切り出し
- `result_page.dart` の `ref.listen` で loading→data 遷移時に一度だけ `refreshIfStale()` を呼び出す構造に変更

## スクリーンショット
なし（ロジック変更のみ）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし (`flutter analyze`: No issues found)
- [ ] テストを追加または更新済み（必要な場合）