### PR TITLE
[Bug] #168 searchedHistoryProvider の invalidate をファミリー単位に絞り不要なリフェッチを削除

### DIFF
--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -189,7 +189,6 @@ class HistoryController extends _$HistoryController {
       await repository.deleteHistoryWithFavorite(id);
       if (!ref.mounted) return;
       ref.read(favoriteIdsCacheProvider.notifier).remove(id);
-      if (!ref.mounted) return;
       // (false) は FavoriteIdsCache の remove により自動再計算される
       ref.invalidate(searchedHistoryProvider(true));
     } else {

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -111,8 +111,9 @@ class UserIsFavoriteState extends _$UserIsFavoriteState {
         ref.read(favoriteIdsCacheProvider.notifier).remove(documentID);
       }
 
-      // 履歴一覧を無効化
-      ref.invalidate(searchedHistoryProvider);
+      // searchedHistoryProvider(false) は favoriteIdsCacheProvider を watch しているため
+      // FavoriteIdsCache 更新で自動再計算される。お気に入りタブのみ明示的に無効化する。
+      ref.invalidate(searchedHistoryProvider(true));
 
       // researchWork の state を直接更新（invalidate だと browsing_history の
       // キャッシュ更新タイミングと競合して古い likes が表示されるため）
@@ -188,25 +189,30 @@ class HistoryController extends _$HistoryController {
       await repository.deleteHistoryWithFavorite(id);
       if (!ref.mounted) return;
       ref.read(favoriteIdsCacheProvider.notifier).remove(id);
+      if (!ref.mounted) return;
+      // (false) は FavoriteIdsCache の remove により自動再計算される
+      ref.invalidate(searchedHistoryProvider(true));
     } else {
       await repository.deleteHistory(id);
+      if (!ref.mounted) return;
+      ref.invalidate(searchedHistoryProvider(false));
     }
-    if (!ref.mounted) return;
-    ref.invalidate(searchedHistoryProvider);
   }
 
   Future<void> deleteAllHistory() async {
     final repository = ref.read(userArchiveRepositoryProvider);
     await repository.deleteAllHistory();
     if (!ref.mounted) return;
-    ref.invalidate(searchedHistoryProvider);
+    ref.invalidate(searchedHistoryProvider(false));
+    ref.invalidate(searchedHistoryProvider(true));
   }
 
   Future<void> deleteHistoryBefore(DateTime date) async {
     final repository = ref.read(userArchiveRepositoryProvider);
     await repository.deleteHistoryBefore(date);
     if (!ref.mounted) return;
-    ref.invalidate(searchedHistoryProvider);
+    ref.invalidate(searchedHistoryProvider(false));
+    ref.invalidate(searchedHistoryProvider(true));
   }
 }
 


### PR DESCRIPTION
## 概要
`ref.invalidate(searchedHistoryProvider)` でファミリー全体を無効化していたため、関係ないタブのデータまでSupabaseから再取得していた問題を修正。操作の種類に応じて必要なファミリーのみを明示的に無効化するよう変更した。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #168

## 変更内容

### 修正の考え方
`searchedHistoryProvider(false)`（閲覧履歴タブ）は `ref.watch(favoriteIdsCacheProvider.future)` しているため、`FavoriteIdsCache` が更新されると自動で再計算される。これを活かして明示的な invalidate を最小化した。

### 各操作の変更

| 操作 | 変更前 | 変更後 |
|------|--------|--------|
| `toggle`（お気に入り追加/解除） | `invalidate(family全体)` | `invalidate((true))` のみ（`(false)` は FavoriteIdsCache 更新で自動再計算） |
| `deleteHistory(isFavorite: false)` | `invalidate(family全体)` | `invalidate((false))` のみ |
| `deleteHistory(isFavorite: true)` | `invalidate(family全体)` | `invalidate((true))` のみ（`(false)` は FavoriteIdsCache.remove で自動再計算） |
| `deleteAllHistory` | `invalidate(family全体)` | `invalidate((false))` + `invalidate((true))` |
| `deleteHistoryBefore` | `invalidate(family全体)` | `invalidate((false))` + `invalidate((true))` |

`deleteAllHistory` / `deleteHistoryBefore` は両タブに影響するため両方 invalidate するが、これは以前と同等の動作で変化なし。

## スクリーンショット
なし（UI変更なし）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）