### PR TITLE
[Improvement] #169 お気に入り一覧取得に FavoriteIdsCache を活用し重複 Supabase リクエストを削除

### DIFF
--- a/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
+++ b/lib/features/user_archive/data/repositories/user_archive_repository_impl.dart
@@ -54,6 +54,17 @@ class UserArchiveRepositoryImpl
   }
 
   @override
+  Future<List<Searched>?> getFavoriteHistoryByIds(Set<int> ids) async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return null;
+    try {
+      return await _browsingHistoryDataSource.getHistoryByIds(userId, ids);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
   Future<void> insertHistory(Searched searched) async {
     final userId = FirebaseAuth.instance.currentUser?.uid;
     if (userId == null) return;

--- a/lib/features/user_archive/domain/repositories/user_archive_repository.dart
+++ b/lib/features/user_archive/domain/repositories/user_archive_repository.dart
@@ -7,6 +7,7 @@ abstract class UserArchiveRepository {
   // History
   Future<List<Searched>?> getAllHistory();
   Future<List<Searched>?> getFavoriteHistory();
+  Future<List<Searched>?> getFavoriteHistoryByIds(Set<int> ids);
   Future<void> insertHistory(Searched searched);
   Future<Searched?> getHistory(int documentID);
   Future<void> deleteHistory(int documentID);

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -164,16 +164,23 @@ class UserIsFavoriteState extends _$UserIsFavoriteState {
 @riverpod
 Future<List<Searched>?> searchedHistory(Ref ref, bool onlyShowFavorite) async {
   final repository = ref.watch(userArchiveRepositoryProvider);
+
+  // キャッシュが既にあれば同期的に取得し、ローディング状態を経由しない。
+  // これにより お気に入り追加・削除時の UI ちらつき（再ローディング）を防ぐ。
+  // 初回ロード時（asData が null）のみ future を await してローディング状態を伝播させる。
+  final favoriteIdsValue = ref.watch(favoriteIdsCacheProvider);
+  final favoriteIds = favoriteIdsValue.asData?.value;
+  if (favoriteIds == null) {
+    await ref.watch(favoriteIdsCacheProvider.future);
+    return null;
+  }
+
   if (onlyShowFavorite) {
-    final favoriteIds = await ref.watch(favoriteIdsCacheProvider.future);
     if (favoriteIds.isEmpty) return null;
     return repository.getFavoriteHistoryByIds(favoriteIds);
   } else {
     final history = await repository.getAllHistory();
     if (history == null) return null;
-    // FavoriteIdsCache の初期化完了を待ってから isFavorite を付与する。
-    // これにより初期化前に全件 unfavorited になる競合状態を防ぐ。
-    final favoriteIds = await ref.watch(favoriteIdsCacheProvider.future);
     return history
         .map((h) => h.copyWith(isFavorite: favoriteIds.contains(h.documentID)))
         .toList();

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -165,7 +165,9 @@ class UserIsFavoriteState extends _$UserIsFavoriteState {
 Future<List<Searched>?> searchedHistory(Ref ref, bool onlyShowFavorite) async {
   final repository = ref.watch(userArchiveRepositoryProvider);
   if (onlyShowFavorite) {
-    return repository.getFavoriteHistory();
+    final favoriteIds = await ref.watch(favoriteIdsCacheProvider.future);
+    if (favoriteIds.isEmpty) return null;
+    return repository.getFavoriteHistoryByIds(favoriteIds);
   } else {
     final history = await repository.getAllHistory();
     if (history == null) return null;


### PR DESCRIPTION
## 概要
お気に入り作品一覧タブを開くたびに発生していた `SELECT * FROM favorites WHERE user_id = ?` の重複 Supabase リクエストを削除する。

## 種別
- [ ] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #169

## 変更内容

### 問題
`searchedHistoryProvider(onlyFavorite: true)` の呼び出しチェーンで、ログイン時に既に全 favorite ID を取得・インメモリキャッシュ済みの `FavoriteIdsCache` を使わず、`getFavoriteHistory()` 内で `_favoritesDataSource.getFavoriteIds()` を呼び Supabase を再度フェッチしていた。

**変更前の呼び出しチェーン:**
```
searchedHistoryProvider(true)
  → repository.getFavoriteHistory()
    → _favoritesDataSource.getFavoriteIds()  ← 重複 Supabase リクエスト
    → _browsingHistoryDataSource.getHistoryByIds()
```

### 解決策（検索結果画面と同じ手法を適用）
検索結果表示画面のお気に入り判定と同様に、`searchedHistoryProvider` 内で `FavoriteIdsCache` から ID を直接取得し、`repository.getFavoriteHistoryByIds()` に渡す。

**変更後の呼び出しチェーン:**
```
searchedHistoryProvider(true)
  → ref.watch(favoriteIdsCacheProvider.future)  ← インメモリキャッシュ（追加リクエスト不要）
  → repository.getFavoriteHistoryByIds(favoriteIds)
    → _browsingHistoryDataSource.getHistoryByIds()
```

### 具体的な変更ファイル
- `domain/repositories/user_archive_repository.dart`: `getFavoriteHistoryByIds(Set<int> ids)` をインターフェースに追加
- `data/repositories/user_archive_repository_impl.dart`: `getFavoriteHistoryByIds` の実装を追加（`getHistoryByIds` に委譲）
- `presentation/providers/user_archive_providers.dart`: `searchedHistoryProvider(true)` を `FavoriteIdsCache` 直接参照に変更

### 効果
お気に入りタブを開くたびに発生していた `SELECT * FROM favorites WHERE user_id = ?` のリクエストを削減。

## スクリーンショット
なし（内部ロジックの変更のみ）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし（`dart format` + `flutter analyze` でエラーなし確認済み）
- [ ] テストを追加または更新済み（必要な場合）