### PR TITLE
[fix] Not Foundの作品をロード中のまま表示しないよう修正

### DIFF
--- a/lib/features/research_work/presentation/widgets/display_pdf.dart
+++ b/lib/features/research_work/presentation/widgets/display_pdf.dart
@@ -59,8 +59,11 @@ class DisplayPdf extends ConsumerWidget {
               error: (error, _) {
                 if (error is ServerFailure &&
                     error.code == 'object-not-found') {
-                  return const Center(
-                    child: Text('ファイルが見つかりませんでした'),
+                  return const CommonErrorView(
+                    error: ServerFailure(
+                      message: 'ファイルが見つかりませんでした',
+                      code: 'object-not-found',
+                    ),
                   );
                 }
                 return CommonErrorView(

--- a/lib/features/research_work/presentation/widgets/display_pdf.dart
+++ b/lib/features/research_work/presentation/widgets/display_pdf.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kenryo_tankyu/core/error/failures.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/providers/searched_provider.dart';
 import 'package:flutter_pdfview/flutter_pdfview.dart';
@@ -55,12 +56,20 @@ class DisplayPdf extends ConsumerWidget {
                 );
               },
               loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) => CommonErrorView(
-                error: error,
-                onRetry: () => ref.invalidate(
-                  pdfProvider(nowWatchingPdf, searched.enterYear),
-                ),
-              ),
+              error: (error, _) {
+                if (error is ServerFailure &&
+                    error.code == 'object-not-found') {
+                  return const Center(
+                    child: Text('ファイルが見つかりませんでした'),
+                  );
+                }
+                return CommonErrorView(
+                  error: error,
+                  onRetry: () => ref.invalidate(
+                    pdfProvider(nowWatchingPdf, searched.enterYear),
+                  ),
+                );
+              },
             );
           }),
           Align(


### PR DESCRIPTION
## 概要
Firebase Storage にPDFが存在しない作品を開いた際、ローディングが終わらずユーザーが通信不良と誤解する問題を修正。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #176

## 変更内容
- `display_pdf.dart` のエラーハンドラーで、`ServerFailure` かつ code が `object-not-found`（Firebase Storage のファイル未存在エラー）の場合に「ファイルが見つかりませんでした」をセンタリングして表示するよう対応
- それ以外のエラーは従来通り `CommonErrorView`（リトライボタン付き）を表示

## スクリーンショット
なし（エラー状態の再現が必要なため）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）