### PR TITLE
[fix] スクリーンショット警告の誤字修正と共有ボタンの追加

### DIFF
--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -129,6 +129,7 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
   }
 
   void _showAlertDialog() {
+    if (!mounted) return;
     final searchedAsync = ref.read(searchedItemProvider(widget.documentID));
     final searched = searchedAsync.hasValue ? searchedAsync.requireValue : null;
     showDialog(

--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/providers/searched_provider.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/screens/pdf_expand_page.dart';
+import 'package:kenryo_tankyu/features/research_work/presentation/utils/share_helper.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/widgets/header_for_result.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/widgets/work_title.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/widgets/work_details_table.dart';
@@ -128,14 +129,24 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
   }
 
   void _showAlertDialog() {
+    final searchedAsync = ref.read(searchedItemProvider(widget.documentID));
+    final searched = searchedAsync.hasValue ? searchedAsync.requireValue : null;
     showDialog(
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: const Text('⚠️注意⚠ｚ️'),
+          title: const Text('⚠️注意⚠️'),
           content: const Text(
               'スクリーンショットを検知しました。\nプライバシー保護の観点から、第三者に撮った画面を共有しないでください。'),
           actions: [
+            if (searched != null)
+              TextButton(
+                onPressed: () async {
+                  Navigator.of(context).pop();
+                  await shareSearched(searched);
+                },
+                child: const Text('代わりに共有する...'),
+              ),
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop();

--- a/lib/features/research_work/presentation/utils/share_helper.dart
+++ b/lib/features/research_work/presentation/utils/share_helper.dart
@@ -1,0 +1,20 @@
+import 'package:share_plus/share_plus.dart';
+import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+
+String buildShareText(Searched searched) {
+  final url = 'https://tankyu-app.web.app/result/${searched.documentID}';
+  return '『${searched.title}』\n'
+      '${searched.enterYear.displayName}年度入学／${searched.course.displayName}\n'
+      '名前：${searched.author}\n'
+      '---------\n'
+      'カテゴリ1：${searched.category1.displayName}>${searched.subCategory1.displayName}\n'
+      'カテゴリ2：${searched.category2.displayName}>${searched.subCategory2.displayName}\n'
+      '---------\n'
+      '$url';
+}
+
+Future<void> shareSearched(Searched searched) async {
+  await SharePlus.instance.share(
+    ShareParams(text: buildShareText(searched)),
+  );
+}

--- a/lib/features/research_work/presentation/widgets/header_for_result.dart
+++ b/lib/features/research_work/presentation/widgets/header_for_result.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/providers/searched_provider.dart';
+import 'package:kenryo_tankyu/features/research_work/presentation/utils/share_helper.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/widgets/overlay_dialog.dart';
 
 class HeaderForResultPage extends ConsumerWidget
@@ -45,12 +45,7 @@ class HeaderForResultPage extends ConsumerWidget
                     child: const Text('情報の変更を提案'),
                   ),
                   PopupMenuItem(
-                    onTap: () async {
-                      final shareText = _buildShareText(searched);
-                      await SharePlus.instance.share(
-                        ShareParams(text: shareText),
-                      );
-                    },
+                    onTap: () async => shareSearched(searched),
                     child: const Text('共有する...'),
                   ),
                 ];
@@ -62,17 +57,5 @@ class HeaderForResultPage extends ConsumerWidget
         ),
       ],
     );
-  }
-
-  String _buildShareText(Searched searched) {
-    final url = 'https://tankyu-app.web.app/result/${searched.documentID}';
-    return '『${searched.title}』\n'
-        '${searched.enterYear.displayName}年度入学／${searched.course.displayName}\n'
-        '名前：${searched.author}\n'
-        '---------\n'
-        'カテゴリ1：${searched.category1.displayName}>${searched.subCategory1.displayName}\n'
-        'カテゴリ2：${searched.category2.displayName}>${searched.subCategory2.displayName}\n'
-        '---------\n'
-        '$url';
   }
 }


### PR DESCRIPTION
## 概要
スクリーンショット検知ダイアログの誤字を修正し、share_plus を使った「代わりに共有する...」ボタンを追加する。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #175

## 変更内容
- ダイアログタイトルの誤字 `⚠️注意⚠ｚ️` を `⚠️注意⚠️` に修正
- スクリーンショット警告ダイアログに「代わりに共有する...」ボタンを追加
  - Searched データが取得済みの場合のみ表示
  - タップするとダイアログを閉じた後に share_plus で共有シートを開く
- 共有ロジックを `presentation/utils/share_helper.dart` に切り出し
  - `buildShareText(Searched)` と `shareSearched(Searched)` を定義
  - `header_for_result.dart` のインライン実装も同ユーティリティに統一

## スクリーンショット
（実機確認済み）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）