### PR TITLE
[iOS] FirebaseFirestore をプリビルドバイナリに切り替えてビルドを高速化

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,6 +30,10 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
 
+  # FirebaseFirestore のコンパイル済みバイナリを使用してビルドを高速化
+  # https://github.com/invertase/firestore-ios-sdk-frameworks
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '12.4.0'
+
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do
     inherit! :search_paths


### PR DESCRIPTION
## 概要
iOSビルド時に FirebaseFirestore のソースコードがフルコンパイルされるため時間がかかっていた問題を解消する。

## 種別
- [ ] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [x] その他（ビルド高速化）

## 関連Issue
Closes #  

## 変更内容
- `ios/Podfile` に `FirebaseFirestore` のプリビルドバイナリソースを追加
  - `invertase/firestore-ios-sdk-frameworks` の tag `12.4.0` を参照
  - `pod install` 時にソースコードのコンパイルが不要になり、初回・クリーンビルドが大幅に高速化される
  - 参考: https://github.com/invertase/firestore-ios-sdk-frameworks

## スクリーンショット
なし（ビルド設定変更のみ）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）