### PR TITLE
[add] Firebase CrashlyticsとAnalyticsによるエラー収集システム構築

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,6 +67,12 @@ platform :ios do
       clean: false,
     )
 
+    # dSYM を Firebase Crashlytics にアップロード（クラッシュログのシンボル解決に必要）
+    upload_symbols_to_crashlytics(
+      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+      gsp_path: "ios/Runner/GoogleService-Info.plist",
+    )
+
     api_key
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,7 +32,7 @@ target 'Runner' do
 
   # FirebaseFirestore のコンパイル済みバイナリを使用してビルドを高速化
   # https://github.com/invertase/firestore-ios-sdk-frameworks
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '12.4.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '12.14.0'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do
@@ -43,5 +43,9 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      # Firebase/Storage 等が iOS 16.0 を要求するため、全 pod の最小バージョンを統一する
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
+    end
   end
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,70 +11,108 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - cloud_firestore (6.1.0):
-    - Firebase/Firestore (= 12.4.0)
+  - cloud_firestore (6.5.0):
+    - Firebase/Firestore (= 12.14.0)
     - firebase_core
     - Flutter
   - connectivity_plus (0.0.1):
     - Flutter
   - external_path (2.0.1):
     - Flutter
-  - Firebase/Auth (12.4.0):
+  - Firebase/Auth (12.14.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 12.4.0)
-  - Firebase/CoreOnly (12.4.0):
-    - FirebaseCore (~> 12.4.0)
-  - Firebase/Firestore (12.4.0):
+    - FirebaseAuth (~> 12.14.0)
+  - Firebase/CoreOnly (12.14.0):
+    - FirebaseCore (~> 12.14.0)
+  - Firebase/Crashlytics (12.14.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 12.4.0)
-  - Firebase/Messaging (12.4.0):
+    - FirebaseCrashlytics (~> 12.14.0)
+  - Firebase/Firestore (12.14.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 12.4.0)
-  - Firebase/Storage (12.4.0):
+    - FirebaseFirestore (~> 12.14.0)
+  - Firebase/Messaging (12.14.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 12.4.0)
-  - firebase_auth (6.1.2):
-    - Firebase/Auth (= 12.4.0)
+    - FirebaseMessaging (~> 12.14.0)
+  - Firebase/Storage (12.14.0):
+    - Firebase/CoreOnly
+    - FirebaseStorage (~> 12.14.0)
+  - firebase_analytics (12.4.2):
+    - firebase_core
+    - FirebaseAnalytics (= 12.14.0)
+    - Flutter
+  - firebase_auth (6.5.2):
+    - Firebase/Auth (= 12.14.0)
     - firebase_core
     - Flutter
-  - firebase_core (4.2.1):
-    - Firebase/CoreOnly (= 12.4.0)
+  - firebase_core (4.10.0):
+    - Firebase/CoreOnly (= 12.14.0)
     - Flutter
-  - firebase_messaging (16.0.4):
-    - Firebase/Messaging (= 12.4.0)
+  - firebase_crashlytics (5.2.3):
+    - Firebase/Crashlytics (= 12.14.0)
     - firebase_core
     - Flutter
-  - firebase_storage (13.0.4):
-    - Firebase/Storage (= 12.4.0)
+  - firebase_messaging (16.3.0):
+    - Firebase/Messaging (= 12.14.0)
     - firebase_core
     - Flutter
-  - FirebaseAppCheckInterop (12.4.0)
-  - FirebaseAuth (12.4.0):
-    - FirebaseAppCheckInterop (~> 12.4.0)
-    - FirebaseAuthInterop (~> 12.4.0)
-    - FirebaseCore (~> 12.4.0)
-    - FirebaseCoreExtension (~> 12.4.0)
+  - firebase_storage (13.4.2):
+    - Firebase/Storage (= 12.14.0)
+    - firebase_core
+    - Flutter
+  - FirebaseAnalytics (12.14.0):
+    - FirebaseAnalytics/Default (= 12.14.0)
+    - FirebaseCore (~> 12.14.0)
+    - FirebaseInstallations (~> 12.14.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - FirebaseAnalytics/Default (12.14.0):
+    - FirebaseCore (~> 12.14.0)
+    - FirebaseInstallations (~> 12.14.0)
+    - GoogleAppMeasurement/Default (= 12.14.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - FirebaseAppCheckInterop (12.14.0)
+  - FirebaseAuth (12.14.0):
+    - FirebaseAppCheckInterop (~> 12.14.0)
+    - FirebaseAuthInterop (~> 12.14.0)
+    - FirebaseCore (~> 12.14.0)
+    - FirebaseCoreExtension (~> 12.14.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GTMSessionFetcher/Core (< 6.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
-  - FirebaseAuthInterop (12.4.0)
-  - FirebaseCore (12.4.0):
-    - FirebaseCoreInternal (~> 12.4.0)
+  - FirebaseAuthInterop (12.14.0)
+  - FirebaseCore (12.14.0):
+    - FirebaseCoreInternal (~> 12.14.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreExtension (12.4.0):
-    - FirebaseCore (~> 12.4.0)
-  - FirebaseCoreInternal (12.4.0):
+  - FirebaseCoreExtension (12.14.0):
+    - FirebaseCore (~> 12.14.0)
+  - FirebaseCoreInternal (12.14.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseFirestore (12.4.0):
-    - FirebaseFirestoreBinary (= 12.4.0)
+  - FirebaseCrashlytics (12.14.0):
+    - FirebaseCore (~> 12.14.0)
+    - FirebaseInstallations (~> 12.14.0)
+    - FirebaseRemoteConfigInterop (~> 12.14.0)
+    - FirebaseSessions (~> 12.14.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseFirestore (12.14.0):
+    - FirebaseFirestoreBinary (= 12.14.0)
   - FirebaseFirestoreAbseilBinary (1.2024072200.0)
-  - FirebaseFirestoreBinary (12.4.0):
-    - FirebaseCore (= 12.4.0)
-    - FirebaseCoreExtension (= 12.4.0)
-    - FirebaseFirestoreInternalBinary (= 12.4.0)
-    - FirebaseSharedSwift (= 12.4.0)
+  - FirebaseFirestoreBinary (12.14.0):
+    - FirebaseCore (= 12.14.0)
+    - FirebaseCoreExtension (= 12.14.0)
+    - FirebaseFirestoreInternalBinary (= 12.14.0)
+    - FirebaseSharedSwift (= 12.14.0)
   - FirebaseFirestoreGRPCBoringSSLBinary (1.69.0)
   - FirebaseFirestoreGRPCCoreBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
@@ -82,32 +120,42 @@ PODS:
   - FirebaseFirestoreGRPCCPPBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCoreBinary (= 1.69.0)
-  - FirebaseFirestoreInternalBinary (12.4.0):
-    - FirebaseCore (= 12.4.0)
+  - FirebaseFirestoreInternalBinary (12.14.0):
+    - FirebaseCore (= 12.14.0)
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCPPBinary (= 1.69.0)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseInstallations (12.4.0):
-    - FirebaseCore (~> 12.4.0)
+  - FirebaseInstallations (12.14.0):
+    - FirebaseCore (~> 12.14.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (12.4.0):
-    - FirebaseCore (~> 12.4.0)
-    - FirebaseInstallations (~> 12.4.0)
+  - FirebaseMessaging (12.14.0):
+    - FirebaseCore (~> 12.14.0)
+    - FirebaseInstallations (~> 12.14.0)
     - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Reachability (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - FirebaseSharedSwift (12.4.0)
-  - FirebaseStorage (12.4.0):
-    - FirebaseAppCheckInterop (~> 12.4.0)
-    - FirebaseAuthInterop (~> 12.4.0)
-    - FirebaseCore (~> 12.4.0)
-    - FirebaseCoreExtension (~> 12.4.0)
+  - FirebaseRemoteConfigInterop (12.14.0)
+  - FirebaseSessions (12.14.0):
+    - FirebaseCore (~> 12.14.0)
+    - FirebaseCoreExtension (~> 12.14.0)
+    - FirebaseInstallations (~> 12.14.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
+    - PromisesSwift (~> 2.1)
+  - FirebaseSharedSwift (12.14.0)
+  - FirebaseStorage (12.14.0):
+    - FirebaseAppCheckInterop (~> 12.14.0)
+    - FirebaseAuthInterop (~> 12.14.0)
+    - FirebaseCore (~> 12.14.0)
+    - FirebaseCoreExtension (~> 12.14.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GTMSessionFetcher/Core (< 6.0, >= 3.4)
   - Flutter (1.0.0)
@@ -120,10 +168,37 @@ PODS:
     - FlutterMacOS
     - GoogleSignIn (~> 9.0)
     - GTMSessionFetcher (>= 3.4.0)
+  - GoogleAdsOnDeviceConversion (3.6.0):
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - nanopb (~> 3.30910.0)
+  - GoogleAppMeasurement/Core (12.14.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - GoogleAppMeasurement/Default (12.14.0):
+    - GoogleAdsOnDeviceConversion (~> 3.6.0)
+    - GoogleAppMeasurement/Core (= 12.14.0)
+    - GoogleAppMeasurement/IdentitySupport (= 12.14.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - GoogleAppMeasurement/IdentitySupport (12.14.0):
+    - GoogleAppMeasurement/Core (= 12.14.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - GoogleSignIn (9.0.0):
+  - GoogleSignIn (9.1.0):
     - AppAuth (~> 2.0)
     - AppCheckCore (~> 11.0)
     - GTMAppAuth (~> 5.0)
@@ -137,6 +212,9 @@ PODS:
     - GoogleUtilities/Privacy
   - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/MethodSwizzler (8.1.0):
+    - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - GoogleUtilities/Network (8.1.0):
     - GoogleUtilities/Logger
@@ -169,9 +247,11 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - permission_handler_apple (9.3.0):
+  - permission_handler_apple (9.4.8):
     - Flutter
   - PromisesObjC (2.4.0)
+  - PromisesSwift (2.4.0):
+    - PromisesObjC (= 2.4.0)
   - RecaptchaInterop (101.0.0)
   - screen_capture_event (0.0.1):
     - Flutter
@@ -193,11 +273,13 @@ DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - external_path (from `.symlinks/plugins/external_path/ios`)
+  - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
+  - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `12.4.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `12.14.0`)
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_pdfview (from `.symlinks/plugins/flutter_pdfview/ios`)
@@ -216,12 +298,14 @@ SPEC REPOS:
     - AppAuth
     - AppCheckCore
     - Firebase
+    - FirebaseAnalytics
     - FirebaseAppCheckInterop
     - FirebaseAuth
     - FirebaseAuthInterop
     - FirebaseCore
     - FirebaseCoreExtension
     - FirebaseCoreInternal
+    - FirebaseCrashlytics
     - FirebaseFirestoreAbseilBinary
     - FirebaseFirestoreBinary
     - FirebaseFirestoreGRPCBoringSSLBinary
@@ -230,8 +314,12 @@ SPEC REPOS:
     - FirebaseFirestoreInternalBinary
     - FirebaseInstallations
     - FirebaseMessaging
+    - FirebaseRemoteConfigInterop
+    - FirebaseSessions
     - FirebaseSharedSwift
     - FirebaseStorage
+    - GoogleAdsOnDeviceConversion
+    - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleSignIn
     - GoogleUtilities
@@ -240,6 +328,7 @@ SPEC REPOS:
     - leveldb-library
     - nanopb
     - PromisesObjC
+    - PromisesSwift
     - RecaptchaInterop
 
 EXTERNAL SOURCES:
@@ -251,17 +340,21 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/connectivity_plus/ios"
   external_path:
     :path: ".symlinks/plugins/external_path/ios"
+  firebase_analytics:
+    :path: ".symlinks/plugins/firebase_analytics/ios"
   firebase_auth:
     :path: ".symlinks/plugins/firebase_auth/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
+  firebase_crashlytics:
+    :path: ".symlinks/plugins/firebase_crashlytics/ios"
   firebase_messaging:
     :path: ".symlinks/plugins/firebase_messaging/ios"
   firebase_storage:
     :path: ".symlinks/plugins/firebase_storage/ios"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 12.4.0
+    :tag: 12.14.0
   Flutter:
     :path: Flutter
   flutter_native_splash:
@@ -290,51 +383,60 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 12.4.0
+    :tag: 12.14.0
 
 SPEC CHECKSUMS:
   app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  cloud_firestore: 7a6d8a533ec7418a7fe46b3a5dabf55661a5b298
+  cloud_firestore: 0b00f29ae2bb05adf7b0624b4aa883861a59761d
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   external_path: fd37c654b69a1336e33a2403f48383ae6100e443
-  Firebase: f07b15ae5a6ec0f93713e30b923d9970d144af3e
-  firebase_auth: 9225db04db5d8e3b46dc8940e04bc6aec6833e27
-  firebase_core: f1aafb21c14f497e5498f7ffc4dc63cbb52b2594
-  firebase_messaging: c17a29984eafce4b2997fe078bb0a9e0b06f5dde
-  firebase_storage: d558bbfa99449fff39352db83c466c8515fa1afa
-  FirebaseAppCheckInterop: f734c802f21fe1da0837708f0f9a27218c8a4ed0
-  FirebaseAuth: 4a2aed737c84114a9d9b33d11ae1b147d6b94889
-  FirebaseAuthInterop: 858e6b754966e70740a4370dd1503dfffe6dbb49
-  FirebaseCore: bb595f3114953664e3c1dc032f008a244147cfd3
-  FirebaseCoreExtension: 7e1f7118ee970e001a8013719fb90950ee5e0018
-  FirebaseCoreInternal: d7f5a043c2cd01a08103ab586587c1468047bca6
-  FirebaseFirestore: 5fa679a528af694e2a13f1129390e9d26e45cdbc
+  Firebase: 7cc10425300768ec86292688af5cb228f0604bde
+  firebase_analytics: 9ea6c22e60e1d37ee76772de57b4addddb03e276
+  firebase_auth: d4091ec40b52cc2ea56171ea521c30b388844acb
+  firebase_core: 383e19b49a08df5d7a6cf5017616de6a357ed7af
+  firebase_crashlytics: 88273c8643a258ff74ee26203e319a782aa8b12c
+  firebase_messaging: ab03d6090864c0fb8136521231df6a66cb13be49
+  firebase_storage: 152b3447cf137c80da290a2592dc76b82cc7542b
+  FirebaseAnalytics: 99364329a3ea4d1ab4a3744b5464371b7351c481
+  FirebaseAppCheckInterop: f123c0261a7b46f060e98fc2961651f1ac68f384
+  FirebaseAuth: 01a77d472aec77ec008141e7d859d1b9cb8dc2cf
+  FirebaseAuthInterop: 63056ef7f9602e79a8f8d756d4cb35f38e2927c3
+  FirebaseCore: 4939b340b9c598dc1f965d68f8fe57e630b65407
+  FirebaseCoreExtension: ee3e3697acea1062288b1900bcdcab4d59ab93b4
+  FirebaseCoreInternal: 090369a5fffd7423cf88006ab4d2ccc2173a8db9
+  FirebaseCrashlytics: 1fabfdca902d0706cb51bf839edb58b45db421ff
+  FirebaseFirestore: 96a5ed77ea198690ab33c3def8bf34e75c83aa7d
   FirebaseFirestoreAbseilBinary: 4cfa8823cedc1b774843e04fe578ad279b387f97
-  FirebaseFirestoreBinary: 597b166241200acda2ff1057e6c258332d4f601f
+  FirebaseFirestoreBinary: 3964630b500f7797b040921140aa47fa87a2f79d
   FirebaseFirestoreGRPCBoringSSLBinary: c3dfef3ff448ae2c1c85f9baf9fac5afc4db99fa
   FirebaseFirestoreGRPCCoreBinary: 565534e160a0415d12185f7f171c52a567382fbd
   FirebaseFirestoreGRPCCPPBinary: 6c0134e8d230ee58b9d51dec2a30a48efd6d5dc7
-  FirebaseFirestoreInternalBinary: a8b8c76b1d98d2c7f7c94015f1558f07727ce149
-  FirebaseInstallations: ae9f4902cb5bf1d0c5eaa31ec1f4e5495a0714e2
-  FirebaseMessaging: d33971b7bb252745ea6cd31ab190d1a1df4b8ed5
-  FirebaseSharedSwift: 93426a1de92f19e1199fac5295a4f8df16458daa
-  FirebaseStorage: 20d6b56fb8a40ebaa03d6a2889fe33dac64adb73
+  FirebaseFirestoreInternalBinary: 56285b527f95bbfeff0fc79e10c17f10e6742d99
+  FirebaseInstallations: 7cdc919e29dc54306edeffdbdc1eed1a40d7d1e7
+  FirebaseMessaging: 4803888ce3002188f24e19faa8d2326261538426
+  FirebaseRemoteConfigInterop: 40ecdce5a4feee7643b81342f32f1cded905bb07
+  FirebaseSessions: c9e7b7829265454f08cb68f7f8a6650c9b221bd4
+  FirebaseSharedSwift: 7c659ebf23afdc1e60a05df72a07ad7349f5758f
+  FirebaseStorage: 84d86cc0c0451e56e30f235fce26a264f1de13dc
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   flutter_pdfview: 32bf27bda6fd85b9dd2c09628a824df5081246cf
-  google_sign_in_ios: 00dfa94252eb10278b64828c81bcb7158a81a53a
+  google_sign_in_ios: 000870aa06da9b28d1d0bf7ef70ff0213059dd28
+  GoogleAdsOnDeviceConversion: 80ce443fa1b4b5750913d53a04ecda644ff57744
+  GoogleAppMeasurement: 1987ffa55055dfb22c52e363c31aa50c1e11d349
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleSignIn: c7f09cfbc85a1abf69187be091997c317cc33b77
+  GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   screen_capture_event: efc4eb455e1c5cc304cec85a4372e0a633ff2a7c
   screenshot_callback: 85707df1b45a59407f7de87de2408c2f5312a473
@@ -343,6 +445,6 @@ SPEC CHECKSUMS:
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
-PODFILE CHECKSUM: 71de3e2b4c2ccc3b62bad7de4b0c39700005f418
+PODFILE CHECKSUM: 9c71b10448d541fccec96dec67ee7edd3aeb95b0
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				C9A4F3955702BD67B2709365 /* [CP] Embed Pods Frameworks */,
 				CCDAA2CF8ABC1F2621827AA6 /* [CP] Copy Pods Resources */,
+				86FEC6887A58115FFB1BE52C /* [firebase_crashlytics] Crashlytics Upload Symbols */,
 			);
 			buildRules = (
 			);
@@ -311,6 +312,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		86FEC6887A58115FFB1BE52C /* [firebase_crashlytics] Crashlytics Upload Symbols */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"",
+				"\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/\"",
+				"\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"",
+				"\"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)\"",
+				"\"$(PROJECT_DIR)/firebase_app_id_file.json\"",
+			);
+			name = "[firebase_crashlytics] Crashlytics Upload Symbols";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$PODS_ROOT/FirebaseCrashlytics/upload-symbols\" --flutter-project \"$PROJECT_DIR/firebase_app_id_file.json\" ";
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/lib/core/connectivity/connectivity_provider.g.dart
+++ b/lib/core/connectivity/connectivity_provider.g.dart
@@ -10,7 +10,7 @@ part of 'connectivity_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(connectivity)
-const connectivityProvider = ConnectivityProvider._();
+final connectivityProvider = ConnectivityProvider._();
 
 final class ConnectivityProvider extends $FunctionalProvider<
         AsyncValue<List<ConnectivityResult>>,
@@ -19,7 +19,7 @@ final class ConnectivityProvider extends $FunctionalProvider<
     with
         $FutureModifier<List<ConnectivityResult>>,
         $StreamProvider<List<ConnectivityResult>> {
-  const ConnectivityProvider._()
+  ConnectivityProvider._()
       : super(
           from: null,
           argument: null,
@@ -48,11 +48,11 @@ final class ConnectivityProvider extends $FunctionalProvider<
 String _$connectivityHash() => r'69c6e2db8337a9ff832358c4a079a4846fa6f28c';
 
 @ProviderFor(isConnected)
-const isConnectedProvider = IsConnectedProvider._();
+final isConnectedProvider = IsConnectedProvider._();
 
 final class IsConnectedProvider extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
-  const IsConnectedProvider._()
+  IsConnectedProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/core/providers/firebase_providers.g.dart
+++ b/lib/core/providers/firebase_providers.g.dart
@@ -10,12 +10,12 @@ part of 'firebase_providers.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(firebaseAuth)
-const firebaseAuthProvider = FirebaseAuthProvider._();
+final firebaseAuthProvider = FirebaseAuthProvider._();
 
 final class FirebaseAuthProvider
     extends $FunctionalProvider<FirebaseAuth, FirebaseAuth, FirebaseAuth>
     with $Provider<FirebaseAuth> {
-  const FirebaseAuthProvider._()
+  FirebaseAuthProvider._()
       : super(
           from: null,
           argument: null,
@@ -51,13 +51,13 @@ final class FirebaseAuthProvider
 String _$firebaseAuthHash() => r'912368c3df3f72e4295bf7a8cda93b9c5749d923';
 
 @ProviderFor(firebaseFirestore)
-const firebaseFirestoreProvider = FirebaseFirestoreProvider._();
+final firebaseFirestoreProvider = FirebaseFirestoreProvider._();
 
 final class FirebaseFirestoreProvider extends $FunctionalProvider<
     FirebaseFirestore,
     FirebaseFirestore,
     FirebaseFirestore> with $Provider<FirebaseFirestore> {
-  const FirebaseFirestoreProvider._()
+  FirebaseFirestoreProvider._()
       : super(
           from: null,
           argument: null,
@@ -94,11 +94,11 @@ final class FirebaseFirestoreProvider extends $FunctionalProvider<
 String _$firebaseFirestoreHash() => r'963402713bf9b7cc1fb259d619d9b0184d4dcec1';
 
 @ProviderFor(firebaseStorage)
-const firebaseStorageProvider = FirebaseStorageProvider._();
+final firebaseStorageProvider = FirebaseStorageProvider._();
 
 final class FirebaseStorageProvider extends $FunctionalProvider<FirebaseStorage,
     FirebaseStorage, FirebaseStorage> with $Provider<FirebaseStorage> {
-  const FirebaseStorageProvider._()
+  FirebaseStorageProvider._()
       : super(
           from: null,
           argument: null,
@@ -134,13 +134,13 @@ final class FirebaseStorageProvider extends $FunctionalProvider<FirebaseStorage,
 String _$firebaseStorageHash() => r'aa6946fd2a3470c4f3e2e72956076591cc63b435';
 
 @ProviderFor(firebaseMessaging)
-const firebaseMessagingProvider = FirebaseMessagingProvider._();
+final firebaseMessagingProvider = FirebaseMessagingProvider._();
 
 final class FirebaseMessagingProvider extends $FunctionalProvider<
     FirebaseMessaging,
     FirebaseMessaging,
     FirebaseMessaging> with $Provider<FirebaseMessaging> {
-  const FirebaseMessagingProvider._()
+  FirebaseMessagingProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/core/providers/shared_preferences_provider.g.dart
+++ b/lib/core/providers/shared_preferences_provider.g.dart
@@ -10,13 +10,13 @@ part of 'shared_preferences_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(sharedPreferences)
-const sharedPreferencesProvider = SharedPreferencesProvider._();
+final sharedPreferencesProvider = SharedPreferencesProvider._();
 
 final class SharedPreferencesProvider extends $FunctionalProvider<
     SharedPreferences,
     SharedPreferences,
     SharedPreferences> with $Provider<SharedPreferences> {
-  const SharedPreferencesProvider._()
+  SharedPreferencesProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/core/providers/supabase_provider.g.dart
+++ b/lib/core/providers/supabase_provider.g.dart
@@ -10,12 +10,12 @@ part of 'supabase_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(supabaseClient)
-const supabaseClientProvider = SupabaseClientProvider._();
+final supabaseClientProvider = SupabaseClientProvider._();
 
 final class SupabaseClientProvider
     extends $FunctionalProvider<SupabaseClient, SupabaseClient, SupabaseClient>
     with $Provider<SupabaseClient> {
-  const SupabaseClientProvider._()
+  SupabaseClientProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/core/services/firebase_tracking_service.dart
+++ b/lib/core/services/firebase_tracking_service.dart
@@ -19,9 +19,20 @@ class FirebaseTrackingService {
     };
 
     PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+      if (kDebugMode) {
+        // デバッグ時は Crashlytics に送らず、エラーをコンソールへ流す
+        return false;
+      }
       _crashlytics.recordError(error, stack, fatal: true);
       return true;
     };
+  }
+
+  /// ログイン中ユーザーのメールアドレスを Crashlytics に紐付ける。
+  /// ログアウト時は null を渡してクリアする。
+  static Future<void> setUserEmail(String? email) async {
+    await _crashlytics.setUserIdentifier(email ?? '');
+    await _analytics.setUserId(id: email);
   }
 
   /// PDFが Storage に存在しない (object-not-found) エラーを記録する。
@@ -39,20 +50,22 @@ class FirebaseTrackingService {
     );
   }
 
-  /// ログイン失敗を記録する。
+  /// ログイン失敗を記録する（連続失敗が閾値以上のときだけ呼ぶ想定）。
   static void logAuthFailure({
     required String method,
     required String errorCode,
     required String errorMessage,
+    required int failureCount,
   }) {
     _crashlytics.log(
-      'Auth failure: method=$method code=$errorCode message=$errorMessage',
+      'Auth failure #$failureCount: method=$method code=$errorCode message=$errorMessage',
     );
     _analytics.logEvent(
       name: 'auth_failure',
       parameters: {
         'method': method,
         'error_code': errorCode,
+        'failure_count': failureCount,
       },
     );
   }

--- a/lib/core/services/firebase_tracking_service.dart
+++ b/lib/core/services/firebase_tracking_service.dart
@@ -1,0 +1,69 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
+
+class FirebaseTrackingService {
+  static final FirebaseCrashlytics _crashlytics = FirebaseCrashlytics.instance;
+  static final FirebaseAnalytics _analytics = FirebaseAnalytics.instance;
+
+  /// アプリ起動時に呼ぶ。Flutter/Platformエラーを Crashlytics に流す。
+  static Future<void> initialize() async {
+    await _crashlytics.setCrashlyticsCollectionEnabled(!kDebugMode);
+
+    FlutterError.onError = (FlutterErrorDetails details) {
+      if (kDebugMode) {
+        FlutterError.presentError(details);
+      } else {
+        _crashlytics.recordFlutterFatalError(details);
+      }
+    };
+
+    PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+      _crashlytics.recordError(error, stack, fatal: true);
+      return true;
+    };
+  }
+
+  /// PDFが Storage に存在しない (object-not-found) エラーを記録する。
+  static void logPdfNotFound({
+    required int documentId,
+    required String pdfPath,
+  }) {
+    _crashlytics.log('PDF not found: documentId=$documentId path=$pdfPath');
+    _analytics.logEvent(
+      name: 'pdf_not_found',
+      parameters: {
+        'document_id': documentId,
+        'pdf_path': pdfPath,
+      },
+    );
+  }
+
+  /// ログイン失敗を記録する。
+  static void logAuthFailure({
+    required String method,
+    required String errorCode,
+    required String errorMessage,
+  }) {
+    _crashlytics.log(
+      'Auth failure: method=$method code=$errorCode message=$errorMessage',
+    );
+    _analytics.logEvent(
+      name: 'auth_failure',
+      parameters: {
+        'method': method,
+        'error_code': errorCode,
+      },
+    );
+  }
+
+  /// 任意の非致命的エラーを Crashlytics に記録する。
+  static void recordError(
+    Object error,
+    StackTrace? stack, {
+    String? reason,
+    bool fatal = false,
+  }) {
+    _crashlytics.recordError(error, stack, reason: reason, fatal: fatal);
+  }
+}

--- a/lib/core/services/firebase_tracking_service.dart
+++ b/lib/core/services/firebase_tracking_service.dart
@@ -8,7 +8,9 @@ class FirebaseTrackingService {
 
   /// アプリ起動時に呼ぶ。Flutter/Platformエラーを Crashlytics に流す。
   static Future<void> initialize() async {
-    await _crashlytics.setCrashlyticsCollectionEnabled(!kDebugMode);
+    // デバッグビルドでも Crashlytics を有効にする（テスト・検証用途）
+    // 本番同様の動作を確認するには flutter run --profile を推奨
+    await _crashlytics.setCrashlyticsCollectionEnabled(true);
 
     FlutterError.onError = (FlutterErrorDetails details) {
       if (kDebugMode) {

--- a/lib/features/auth/data/datasources/auth_remote_data_source.g.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'auth_remote_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(authRemoteDataSource)
-const authRemoteDataSourceProvider = AuthRemoteDataSourceProvider._();
+final authRemoteDataSourceProvider = AuthRemoteDataSourceProvider._();
 
 final class AuthRemoteDataSourceProvider extends $FunctionalProvider<
     AuthRemoteDataSource,
     AuthRemoteDataSource,
     AuthRemoteDataSource> with $Provider<AuthRemoteDataSource> {
-  const AuthRemoteDataSourceProvider._()
+  AuthRemoteDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,7 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kenryo_tankyu/core/error/error_mapper.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
-import 'package:kenryo_tankyu/core/services/firebase_tracking_service.dart';
 import 'package:kenryo_tankyu/features/auth/data/datasources/auth_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/auth/domain/repositories/auth_repository.dart';
 import 'package:kenryo_tankyu/features/auth/domain/models/auth_failure.dart';
@@ -24,13 +23,7 @@ class AuthRepositoryImpl with ErrorMapper implements AuthRepository {
           .signInWithEmailAndPassword(email: email, password: password)
           .timeout(const Duration(seconds: 10));
     } on FirebaseAuthException catch (e) {
-      final failure = _mapFirebaseException(e);
-      FirebaseTrackingService.logAuthFailure(
-        method: 'signIn',
-        errorCode: e.code,
-        errorMessage: e.message ?? '',
-      );
-      throw failure;
+      throw _mapFirebaseException(e);
     } catch (e) {
       throw mapException(e);
     }
@@ -44,13 +37,7 @@ class AuthRepositoryImpl with ErrorMapper implements AuthRepository {
           .createUserWithEmailAndPassword(email: email, password: password)
           .timeout(const Duration(seconds: 10));
     } on FirebaseAuthException catch (e) {
-      final failure = _mapFirebaseException(e);
-      FirebaseTrackingService.logAuthFailure(
-        method: 'createUser',
-        errorCode: e.code,
-        errorMessage: e.message ?? '',
-      );
-      throw failure;
+      throw _mapFirebaseException(e);
     } catch (e) {
       throw mapException(e);
     }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kenryo_tankyu/core/error/error_mapper.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
+import 'package:kenryo_tankyu/core/services/firebase_tracking_service.dart';
 import 'package:kenryo_tankyu/features/auth/data/datasources/auth_remote_data_source.dart';
 import 'package:kenryo_tankyu/features/auth/domain/repositories/auth_repository.dart';
 import 'package:kenryo_tankyu/features/auth/domain/models/auth_failure.dart';
@@ -23,7 +24,13 @@ class AuthRepositoryImpl with ErrorMapper implements AuthRepository {
           .signInWithEmailAndPassword(email: email, password: password)
           .timeout(const Duration(seconds: 10));
     } on FirebaseAuthException catch (e) {
-      throw _mapFirebaseException(e);
+      final failure = _mapFirebaseException(e);
+      FirebaseTrackingService.logAuthFailure(
+        method: 'signIn',
+        errorCode: e.code,
+        errorMessage: e.message ?? '',
+      );
+      throw failure;
     } catch (e) {
       throw mapException(e);
     }
@@ -37,7 +44,13 @@ class AuthRepositoryImpl with ErrorMapper implements AuthRepository {
           .createUserWithEmailAndPassword(email: email, password: password)
           .timeout(const Duration(seconds: 10));
     } on FirebaseAuthException catch (e) {
-      throw _mapFirebaseException(e);
+      final failure = _mapFirebaseException(e);
+      FirebaseTrackingService.logAuthFailure(
+        method: 'createUser',
+        errorCode: e.code,
+        errorMessage: e.message ?? '',
+      );
+      throw failure;
     } catch (e) {
       throw mapException(e);
     }

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
 import "package:kenryo_tankyu/core/constants/feature/user_value.dart";
+import 'package:kenryo_tankyu/core/services/firebase_tracking_service.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_repository_provider.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/providers/user_repository_provider.dart';
 import 'package:kenryo_tankyu/features/auth/domain/models/auth.dart';
@@ -24,6 +25,9 @@ Stream<User?> authStateChanges(Ref ref) {
 
 @riverpod
 class AuthNotifier extends _$AuthNotifier {
+  // ログイン連続失敗回数（セッション内で保持）
+  int _loginFailureCount = 0;
+
   @override
   Auth build() {
     ref.listen<AsyncValue<User?>>(
@@ -32,6 +36,9 @@ class AuthNotifier extends _$AuthNotifier {
       (_, next) {
         next.whenData((user) {
           if (user != null && user.emailVerified) {
+            // ログイン成功時にユーザーメールを Crashlytics に紐付け
+            unawaited(FirebaseTrackingService.setUserEmail(user.email));
+            _loginFailureCount = 0;
             // FavoriteIdsCache は authStateChangesProvider を watch して自己初期化するため不要
             unawaited(
               ref.read(searchHistoryCacheProvider.notifier).initialize(),
@@ -42,6 +49,7 @@ class AuthNotifier extends _$AuthNotifier {
                   .initialize(user.uid),
             );
           } else {
+            unawaited(FirebaseTrackingService.setUserEmail(null));
             // FavoriteIdsCache は authStateChangesProvider を watch して自動リセットするため不要
             ref.invalidate(searchHistoryCacheProvider);
             ref.invalidate(readNotificationIdsProvider);
@@ -80,8 +88,23 @@ class AuthNotifier extends _$AuthNotifier {
     final authRepo = ref.read(authRepositoryProvider);
     final userRepo = ref.read(userRepositoryProvider);
     final email = rawEmail.contains('@') ? rawEmail : '$rawEmail@kenryo.ed.jp';
-    await authRepo.signInWithEmailAndPassword(email: email, password: password);
-    await userRepo.updateRegisteredStatus(email: email, isRegistered: true);
+    try {
+      await authRepo.signInWithEmailAndPassword(
+          email: email, password: password);
+      await userRepo.updateRegisteredStatus(email: email, isRegistered: true);
+    } catch (e) {
+      _loginFailureCount++;
+      // 2回目以降の失敗をトラッキング（操作ミスの1回は除外）
+      if (_loginFailureCount >= 2) {
+        FirebaseTrackingService.logAuthFailure(
+          method: 'signIn',
+          errorCode: e.runtimeType.toString(),
+          errorMessage: e.toString(),
+          failureCount: _loginFailureCount,
+        );
+      }
+      rethrow;
+    }
   }
 
   Future<void> sendVerifyEmail() async {

--- a/lib/features/auth/presentation/providers/auth_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.g.dart
@@ -10,12 +10,12 @@ part of 'auth_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(authStateChanges)
-const authStateChangesProvider = AuthStateChangesProvider._();
+final authStateChangesProvider = AuthStateChangesProvider._();
 
 final class AuthStateChangesProvider
     extends $FunctionalProvider<AsyncValue<User?>, User?, Stream<User?>>
     with $FutureModifier<User?>, $StreamProvider<User?> {
-  const AuthStateChangesProvider._()
+  AuthStateChangesProvider._()
       : super(
           from: null,
           argument: null,
@@ -43,10 +43,10 @@ final class AuthStateChangesProvider
 String _$authStateChangesHash() => r'f95512f3016c4609549bf37ef775d5ac547a7179';
 
 @ProviderFor(AuthNotifier)
-const authProvider = AuthNotifierProvider._();
+final authProvider = AuthNotifierProvider._();
 
 final class AuthNotifierProvider extends $NotifierProvider<AuthNotifier, Auth> {
-  const AuthNotifierProvider._()
+  AuthNotifierProvider._()
       : super(
           from: null,
           argument: null,
@@ -80,10 +80,9 @@ abstract class _$AuthNotifier extends $Notifier<Auth> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<Auth, Auth>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Auth, Auth>, Auth, Object?, Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/features/auth/presentation/providers/auth_repository_provider.g.dart
+++ b/lib/features/auth/presentation/providers/auth_repository_provider.g.dart
@@ -10,12 +10,12 @@ part of 'auth_repository_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(authRepository)
-const authRepositoryProvider = AuthRepositoryProvider._();
+final authRepositoryProvider = AuthRepositoryProvider._();
 
 final class AuthRepositoryProvider
     extends $FunctionalProvider<AuthRepository, AuthRepository, AuthRepository>
     with $Provider<AuthRepository> {
-  const AuthRepositoryProvider._()
+  AuthRepositoryProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/auth/presentation/providers/user_repository_provider.g.dart
+++ b/lib/features/auth/presentation/providers/user_repository_provider.g.dart
@@ -10,12 +10,12 @@ part of 'user_repository_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(userRepository)
-const userRepositoryProvider = UserRepositoryProvider._();
+final userRepositoryProvider = UserRepositoryProvider._();
 
 final class UserRepositoryProvider
     extends $FunctionalProvider<UserRepository, UserRepository, UserRepository>
     with $Provider<UserRepository> {
-  const UserRepositoryProvider._()
+  UserRepositoryProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/notification/data/datasources/notification_local_data_source.g.dart
+++ b/lib/features/notification/data/datasources/notification_local_data_source.g.dart
@@ -10,14 +10,14 @@ part of 'notification_local_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(notificationLocalDataSource)
-const notificationLocalDataSourceProvider =
+final notificationLocalDataSourceProvider =
     NotificationLocalDataSourceProvider._();
 
 final class NotificationLocalDataSourceProvider extends $FunctionalProvider<
     NotificationLocalDataSource,
     NotificationLocalDataSource,
     NotificationLocalDataSource> with $Provider<NotificationLocalDataSource> {
-  const NotificationLocalDataSourceProvider._()
+  NotificationLocalDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/notification/data/datasources/notification_remote_data_source.g.dart
+++ b/lib/features/notification/data/datasources/notification_remote_data_source.g.dart
@@ -10,14 +10,14 @@ part of 'notification_remote_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(notificationRemoteDataSource)
-const notificationRemoteDataSourceProvider =
+final notificationRemoteDataSourceProvider =
     NotificationRemoteDataSourceProvider._();
 
 final class NotificationRemoteDataSourceProvider extends $FunctionalProvider<
     NotificationRemoteDataSource,
     NotificationRemoteDataSource,
     NotificationRemoteDataSource> with $Provider<NotificationRemoteDataSource> {
-  const NotificationRemoteDataSourceProvider._()
+  NotificationRemoteDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/notification/data/repositories/notification_repository_impl.g.dart
+++ b/lib/features/notification/data/repositories/notification_repository_impl.g.dart
@@ -10,13 +10,13 @@ part of 'notification_repository_impl.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(notificationRepository)
-const notificationRepositoryProvider = NotificationRepositoryProvider._();
+final notificationRepositoryProvider = NotificationRepositoryProvider._();
 
 final class NotificationRepositoryProvider extends $FunctionalProvider<
     NotificationRepository,
     NotificationRepository,
     NotificationRepository> with $Provider<NotificationRepository> {
-  const NotificationRepositoryProvider._()
+  NotificationRepositoryProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/notification/presentation/providers/read_notification_ids_provider.g.dart
+++ b/lib/features/notification/presentation/providers/read_notification_ids_provider.g.dart
@@ -10,11 +10,11 @@ part of 'read_notification_ids_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(ReadNotificationIds)
-const readNotificationIdsProvider = ReadNotificationIdsProvider._();
+final readNotificationIdsProvider = ReadNotificationIdsProvider._();
 
 final class ReadNotificationIdsProvider
     extends $NotifierProvider<ReadNotificationIds, Set<String>> {
-  const ReadNotificationIdsProvider._()
+  ReadNotificationIdsProvider._()
       : super(
           from: null,
           argument: null,
@@ -42,17 +42,16 @@ final class ReadNotificationIdsProvider
 }
 
 String _$readNotificationIdsHash() =>
-    r'9a635cb0fc2565620dd08207ffbbfec03904107a';
+    r'08da3d4aff6c05bfe5a9b14daa754b00e5a9b127';
 
 abstract class _$ReadNotificationIds extends $Notifier<Set<String>> {
   Set<String> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<Set<String>, Set<String>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Set<String>, Set<String>>, Set<String>, Object?, Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/features/research_work/data/datasources/research_work_data_source.g.dart
+++ b/lib/features/research_work/data/datasources/research_work_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'research_work_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(researchWorkDataSource)
-const researchWorkDataSourceProvider = ResearchWorkDataSourceProvider._();
+final researchWorkDataSourceProvider = ResearchWorkDataSourceProvider._();
 
 final class ResearchWorkDataSourceProvider extends $FunctionalProvider<
     ResearchWorkDataSource,
     ResearchWorkDataSource,
     ResearchWorkDataSource> with $Provider<ResearchWorkDataSource> {
-  const ResearchWorkDataSourceProvider._()
+  ResearchWorkDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/research_work/data/repositories/research_work_repository_impl.g.dart
+++ b/lib/features/research_work/data/repositories/research_work_repository_impl.g.dart
@@ -10,13 +10,13 @@ part of 'research_work_repository_impl.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(researchWorkRepository)
-const researchWorkRepositoryProvider = ResearchWorkRepositoryProvider._();
+final researchWorkRepositoryProvider = ResearchWorkRepositoryProvider._();
 
 final class ResearchWorkRepositoryProvider extends $FunctionalProvider<
     ResearchWorkRepository,
     ResearchWorkRepository,
     ResearchWorkRepository> with $Provider<ResearchWorkRepository> {
-  const ResearchWorkRepositoryProvider._()
+  ResearchWorkRepositoryProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/research_work/presentation/providers/searched_provider.g.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.g.dart
@@ -10,11 +10,11 @@ part of 'searched_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(ResearchWork)
-const researchWorkProvider = ResearchWorkFamily._();
+final researchWorkProvider = ResearchWorkFamily._();
 
 final class ResearchWorkProvider
     extends $AsyncNotifierProvider<ResearchWork, Searched> {
-  const ResearchWorkProvider._(
+  ResearchWorkProvider._(
       {required ResearchWorkFamily super.from, required int super.argument})
       : super(
           retry: null,
@@ -55,7 +55,7 @@ final class ResearchWorkFamily extends $Family
     with
         $ClassFamilyOverride<ResearchWork, AsyncValue<Searched>, Searched,
             FutureOr<Searched>, int> {
-  const ResearchWorkFamily._()
+  ResearchWorkFamily._()
       : super(
           retry: null,
           name: r'researchWorkProvider',
@@ -83,29 +83,30 @@ abstract class _$ResearchWork extends $AsyncNotifier<Searched> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build(
-      _$args,
-    );
     final ref = this.ref as $Ref<AsyncValue<Searched>, Searched>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Searched>, Searched>,
         AsyncValue<Searched>,
         Object?,
         Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(
+        ref,
+        () => build(
+              _$args,
+            ));
   }
 }
 
 /// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
 
 @ProviderFor(IsRefreshingLikes)
-const isRefreshingLikesProvider = IsRefreshingLikesFamily._();
+final isRefreshingLikesProvider = IsRefreshingLikesFamily._();
 
 /// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
 final class IsRefreshingLikesProvider
     extends $NotifierProvider<IsRefreshingLikes, bool> {
   /// likes のバックグラウンド更新中かどうかを管理するProvider（スナックバー表示に使用）
-  const IsRefreshingLikesProvider._(
+  IsRefreshingLikesProvider._(
       {required IsRefreshingLikesFamily super.from,
       required int super.argument})
       : super(
@@ -155,7 +156,7 @@ String _$isRefreshingLikesHash() => r'40a12be1a7035124b01fc174a12ae43c4313a683';
 
 final class IsRefreshingLikesFamily extends $Family
     with $ClassFamilyOverride<IsRefreshingLikes, bool, bool, bool, int> {
-  const IsRefreshingLikesFamily._()
+  IsRefreshingLikesFamily._()
       : super(
           retry: null,
           name: r'isRefreshingLikesProvider',
@@ -187,12 +188,13 @@ abstract class _$IsRefreshingLikes extends $Notifier<bool> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build(
-      _$args,
-    );
     final ref = this.ref as $Ref<bool, bool>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<bool, bool>, bool, Object?, Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(
+        ref,
+        () => build(
+              _$args,
+            ));
   }
 }

--- a/lib/features/research_work/presentation/widgets/display_pdf.dart
+++ b/lib/features/research_work/presentation/widgets/display_pdf.dart
@@ -5,6 +5,7 @@ import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart
 import 'package:kenryo_tankyu/features/research_work/presentation/providers/searched_provider.dart';
 import 'package:flutter_pdfview/flutter_pdfview.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
+import 'package:kenryo_tankyu/core/services/firebase_tracking_service.dart';
 import 'package:kenryo_tankyu/presentation/widget/error_view.dart';
 
 class DisplayPdf extends ConsumerWidget {
@@ -56,9 +57,13 @@ class DisplayPdf extends ConsumerWidget {
                 );
               },
               loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) {
+              error: (error, stack) {
                 if (error is ServerFailure &&
                     error.code == 'object-not-found') {
+                  FirebaseTrackingService.logPdfNotFound(
+                    documentId: searched.documentID,
+                    pdfPath: nowWatchingPdf,
+                  );
                   return const CommonErrorView(
                     error: ServerFailure(
                       message: 'ファイルが見つかりませんでした',
@@ -66,6 +71,8 @@ class DisplayPdf extends ConsumerWidget {
                     ),
                   );
                 }
+                FirebaseTrackingService.recordError(error, stack,
+                    reason: 'pdf_load_error');
                 return CommonErrorView(
                   error: error,
                   onRetry: () => ref.invalidate(

--- a/lib/features/search/data/datasources/search_data_source.g.dart
+++ b/lib/features/search/data/datasources/search_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'search_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(searchDataSource)
-const searchDataSourceProvider = SearchDataSourceProvider._();
+final searchDataSourceProvider = SearchDataSourceProvider._();
 
 final class SearchDataSourceProvider extends $FunctionalProvider<
     SearchDataSource,
     SearchDataSource,
     SearchDataSource> with $Provider<SearchDataSource> {
-  const SearchDataSourceProvider._()
+  SearchDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/search/data/datasources/search_history_data_source.g.dart
+++ b/lib/features/search/data/datasources/search_history_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'search_history_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(searchHistoryDataSource)
-const searchHistoryDataSourceProvider = SearchHistoryDataSourceProvider._();
+final searchHistoryDataSourceProvider = SearchHistoryDataSourceProvider._();
 
 final class SearchHistoryDataSourceProvider extends $FunctionalProvider<
     SearchHistoryDataSource,
     SearchHistoryDataSource,
     SearchHistoryDataSource> with $Provider<SearchHistoryDataSource> {
-  const SearchHistoryDataSourceProvider._()
+  SearchHistoryDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/search/data/repositories/search_repository_impl.g.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.g.dart
@@ -10,13 +10,13 @@ part of 'search_repository_impl.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(searchRepository)
-const searchRepositoryProvider = SearchRepositoryProvider._();
+final searchRepositoryProvider = SearchRepositoryProvider._();
 
 final class SearchRepositoryProvider extends $FunctionalProvider<
     SearchRepository,
     SearchRepository,
     SearchRepository> with $Provider<SearchRepository> {
-  const SearchRepositoryProvider._()
+  SearchRepositoryProvider._()
       : super(
           from: null,
           argument: null,
@@ -49,4 +49,4 @@ final class SearchRepositoryProvider extends $FunctionalProvider<
   }
 }
 
-String _$searchRepositoryHash() => r'b8b084724253ff80c1ff6cb607664b54c16360ae';
+String _$searchRepositoryHash() => r'4218f581009a5f348c3858e81e25c882374be6f4';

--- a/lib/features/search/presentation/providers/search_history_provider.g.dart
+++ b/lib/features/search/presentation/providers/search_history_provider.g.dart
@@ -10,11 +10,11 @@ part of 'search_history_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(SearchHistoryCache)
-const searchHistoryCacheProvider = SearchHistoryCacheProvider._();
+final searchHistoryCacheProvider = SearchHistoryCacheProvider._();
 
 final class SearchHistoryCacheProvider
     extends $AsyncNotifierProvider<SearchHistoryCache, List<Search>?> {
-  const SearchHistoryCacheProvider._()
+  SearchHistoryCacheProvider._()
       : super(
           from: null,
           argument: null,
@@ -34,20 +34,19 @@ final class SearchHistoryCacheProvider
 }
 
 String _$searchHistoryCacheHash() =>
-    r'255fd3a7e018fbebd7df5d79fc3fd55290551337';
+    r'55a0fc32376ab58e602c718ea9f359e194a44cf0';
 
 abstract class _$SearchHistoryCache extends $AsyncNotifier<List<Search>?> {
   FutureOr<List<Search>?> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<AsyncValue<List<Search>?>, List<Search>?>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Search>?>, List<Search>?>,
         AsyncValue<List<Search>?>,
         Object?,
         Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/features/search/presentation/providers/search_history_repository_provider.g.dart
+++ b/lib/features/search/presentation/providers/search_history_repository_provider.g.dart
@@ -10,13 +10,13 @@ part of 'search_history_repository_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(searchHistoryRepository)
-const searchHistoryRepositoryProvider = SearchHistoryRepositoryProvider._();
+final searchHistoryRepositoryProvider = SearchHistoryRepositoryProvider._();
 
 final class SearchHistoryRepositoryProvider extends $FunctionalProvider<
     SearchHistoryRepository,
     SearchHistoryRepository,
     SearchHistoryRepository> with $Provider<SearchHistoryRepository> {
-  const SearchHistoryRepositoryProvider._()
+  SearchHistoryRepositoryProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/settings/data/datasources/datasources.g.dart
+++ b/lib/features/settings/data/datasources/datasources.g.dart
@@ -10,13 +10,13 @@ part of 'datasources.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(settingsDataSource)
-const settingsDataSourceProvider = SettingsDataSourceProvider._();
+final settingsDataSourceProvider = SettingsDataSourceProvider._();
 
 final class SettingsDataSourceProvider extends $FunctionalProvider<
     SettingsDataSource,
     SettingsDataSource,
     SettingsDataSource> with $Provider<SettingsDataSource> {
-  const SettingsDataSourceProvider._()
+  SettingsDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/settings/data/repositories/settings_repository_impl.g.dart
+++ b/lib/features/settings/data/repositories/settings_repository_impl.g.dart
@@ -10,13 +10,13 @@ part of 'settings_repository_impl.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(settingsRepository)
-const settingsRepositoryProvider = SettingsRepositoryProvider._();
+final settingsRepositoryProvider = SettingsRepositoryProvider._();
 
 final class SettingsRepositoryProvider extends $FunctionalProvider<
     SettingsRepository,
     SettingsRepository,
     SettingsRepository> with $Provider<SettingsRepository> {
-  const SettingsRepositoryProvider._()
+  SettingsRepositoryProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/settings/presentation/providers/settings_providers.g.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.g.dart
@@ -10,11 +10,11 @@ part of 'settings_providers.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(SettingsNotifier)
-const settingsProvider = SettingsNotifierProvider._();
+final settingsProvider = SettingsNotifierProvider._();
 
 final class SettingsNotifierProvider
     extends $AsyncNotifierProvider<SettingsNotifier, void> {
-  const SettingsNotifierProvider._()
+  SettingsNotifierProvider._()
       : super(
           from: null,
           argument: null,
@@ -40,24 +40,23 @@ abstract class _$SettingsNotifier extends $AsyncNotifier<void> {
   @$mustCallSuper
   @override
   void runBuild() {
-    build();
     final ref = this.ref as $Ref<AsyncValue<void>, void>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<void>, void>,
         AsyncValue<void>,
         Object?,
         Object?>;
-    element.handleValue(ref, null);
+    element.handleCreate(ref, build);
   }
 }
 
 @ProviderFor(themeMode)
-const themeModeProvider = ThemeModeProvider._();
+final themeModeProvider = ThemeModeProvider._();
 
 final class ThemeModeProvider extends $FunctionalProvider<AsyncValue<ThemeMode>,
         ThemeMode, FutureOr<ThemeMode>>
     with $FutureModifier<ThemeMode>, $FutureProvider<ThemeMode> {
-  const ThemeModeProvider._()
+  ThemeModeProvider._()
       : super(
           from: null,
           argument: null,
@@ -85,12 +84,12 @@ final class ThemeModeProvider extends $FunctionalProvider<AsyncValue<ThemeMode>,
 String _$themeModeHash() => r'd4db32a6d830b04692f9b2d89de15f9f073c85f4';
 
 @ProviderFor(notificationEnabled)
-const notificationEnabledProvider = NotificationEnabledProvider._();
+final notificationEnabledProvider = NotificationEnabledProvider._();
 
 final class NotificationEnabledProvider
     extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
     with $FutureModifier<bool>, $FutureProvider<bool> {
-  const NotificationEnabledProvider._()
+  NotificationEnabledProvider._()
       : super(
           from: null,
           argument: null,
@@ -119,13 +118,13 @@ String _$notificationEnabledHash() =>
     r'15b79648d8f95a700baf52cad4729c3ff66db15a';
 
 @ProviderFor(hasShownNotificationDialog)
-const hasShownNotificationDialogProvider =
+final hasShownNotificationDialogProvider =
     HasShownNotificationDialogProvider._();
 
 final class HasShownNotificationDialogProvider
     extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
     with $FutureModifier<bool>, $FutureProvider<bool> {
-  const HasShownNotificationDialogProvider._()
+  HasShownNotificationDialogProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/teacher/data/datasources/teacher_local_data_source.g.dart
+++ b/lib/features/teacher/data/datasources/teacher_local_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'teacher_local_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(teacherLocalDataSource)
-const teacherLocalDataSourceProvider = TeacherLocalDataSourceProvider._();
+final teacherLocalDataSourceProvider = TeacherLocalDataSourceProvider._();
 
 final class TeacherLocalDataSourceProvider extends $FunctionalProvider<
     TeacherLocalDataSource,
     TeacherLocalDataSource,
     TeacherLocalDataSource> with $Provider<TeacherLocalDataSource> {
-  const TeacherLocalDataSourceProvider._()
+  TeacherLocalDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/teacher/data/datasources/teacher_remote_data_source.g.dart
+++ b/lib/features/teacher/data/datasources/teacher_remote_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'teacher_remote_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(teacherRemoteDataSource)
-const teacherRemoteDataSourceProvider = TeacherRemoteDataSourceProvider._();
+final teacherRemoteDataSourceProvider = TeacherRemoteDataSourceProvider._();
 
 final class TeacherRemoteDataSourceProvider extends $FunctionalProvider<
     TeacherRemoteDataSource,
     TeacherRemoteDataSource,
     TeacherRemoteDataSource> with $Provider<TeacherRemoteDataSource> {
-  const TeacherRemoteDataSourceProvider._()
+  TeacherRemoteDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/teacher/data/repositories/teacher_repository_impl.g.dart
+++ b/lib/features/teacher/data/repositories/teacher_repository_impl.g.dart
@@ -10,13 +10,13 @@ part of 'teacher_repository_impl.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(teacherRepository)
-const teacherRepositoryProvider = TeacherRepositoryProvider._();
+final teacherRepositoryProvider = TeacherRepositoryProvider._();
 
 final class TeacherRepositoryProvider extends $FunctionalProvider<
     TeacherRepository,
     TeacherRepository,
     TeacherRepository> with $Provider<TeacherRepository> {
-  const TeacherRepositoryProvider._()
+  TeacherRepositoryProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/user_archive/data/datasources/browsing_history_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/browsing_history_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'browsing_history_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(browsingHistoryDataSource)
-const browsingHistoryDataSourceProvider = BrowsingHistoryDataSourceProvider._();
+final browsingHistoryDataSourceProvider = BrowsingHistoryDataSourceProvider._();
 
 final class BrowsingHistoryDataSourceProvider extends $FunctionalProvider<
     BrowsingHistoryDataSource,
     BrowsingHistoryDataSource,
     BrowsingHistoryDataSource> with $Provider<BrowsingHistoryDataSource> {
-  const BrowsingHistoryDataSourceProvider._()
+  BrowsingHistoryDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/user_archive/data/datasources/favorites_remote_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/favorites_remote_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'favorites_remote_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(favoritesRemoteDataSource)
-const favoritesRemoteDataSourceProvider = FavoritesRemoteDataSourceProvider._();
+final favoritesRemoteDataSourceProvider = FavoritesRemoteDataSourceProvider._();
 
 final class FavoritesRemoteDataSourceProvider extends $FunctionalProvider<
     FavoritesRemoteDataSource,
     FavoritesRemoteDataSource,
     FavoritesRemoteDataSource> with $Provider<FavoritesRemoteDataSource> {
-  const FavoritesRemoteDataSourceProvider._()
+  FavoritesRemoteDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/user_archive/data/datasources/pdf_local_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/pdf_local_data_source.g.dart
@@ -10,13 +10,13 @@ part of 'pdf_local_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(pdfLocalDataSource)
-const pdfLocalDataSourceProvider = PdfLocalDataSourceProvider._();
+final pdfLocalDataSourceProvider = PdfLocalDataSourceProvider._();
 
 final class PdfLocalDataSourceProvider extends $FunctionalProvider<
     PdfLocalDataSource,
     PdfLocalDataSource,
     PdfLocalDataSource> with $Provider<PdfLocalDataSource> {
-  const PdfLocalDataSourceProvider._()
+  PdfLocalDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/user_archive/data/datasources/recommended_works_local_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/recommended_works_local_data_source.g.dart
@@ -10,7 +10,7 @@ part of 'recommended_works_local_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(recommendedWorksLocalDataSource)
-const recommendedWorksLocalDataSourceProvider =
+final recommendedWorksLocalDataSourceProvider =
     RecommendedWorksLocalDataSourceProvider._();
 
 final class RecommendedWorksLocalDataSourceProvider extends $FunctionalProvider<
@@ -18,7 +18,7 @@ final class RecommendedWorksLocalDataSourceProvider extends $FunctionalProvider<
         RecommendedWorksLocalDataSource,
         RecommendedWorksLocalDataSource>
     with $Provider<RecommendedWorksLocalDataSource> {
-  const RecommendedWorksLocalDataSourceProvider._()
+  RecommendedWorksLocalDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/user_archive/data/datasources/user_archive_remote_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/user_archive_remote_data_source.g.dart
@@ -10,14 +10,14 @@ part of 'user_archive_remote_data_source.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(userArchiveRemoteDataSource)
-const userArchiveRemoteDataSourceProvider =
+final userArchiveRemoteDataSourceProvider =
     UserArchiveRemoteDataSourceProvider._();
 
 final class UserArchiveRemoteDataSourceProvider extends $FunctionalProvider<
     UserArchiveRemoteDataSource,
     UserArchiveRemoteDataSource,
     UserArchiveRemoteDataSource> with $Provider<UserArchiveRemoteDataSource> {
-  const UserArchiveRemoteDataSourceProvider._()
+  UserArchiveRemoteDataSourceProvider._()
       : super(
           from: null,
           argument: null,

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
@@ -10,13 +10,13 @@ part of 'user_archive_providers.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(userArchiveRepository)
-const userArchiveRepositoryProvider = UserArchiveRepositoryProvider._();
+final userArchiveRepositoryProvider = UserArchiveRepositoryProvider._();
 
 final class UserArchiveRepositoryProvider extends $FunctionalProvider<
     UserArchiveRepository,
     UserArchiveRepository,
     UserArchiveRepository> with $Provider<UserArchiveRepository> {
-  const UserArchiveRepositoryProvider._()
+  UserArchiveRepositoryProvider._()
       : super(
           from: null,
           argument: null,
@@ -54,11 +54,11 @@ String _$userArchiveRepositoryHash() =>
     r'0cc9ca50197c441d2241527354e8fb97cf3d3d4f';
 
 @ProviderFor(FavoriteIdsCache)
-const favoriteIdsCacheProvider = FavoriteIdsCacheProvider._();
+final favoriteIdsCacheProvider = FavoriteIdsCacheProvider._();
 
 final class FavoriteIdsCacheProvider
     extends $AsyncNotifierProvider<FavoriteIdsCache, Set<int>> {
-  const FavoriteIdsCacheProvider._()
+  FavoriteIdsCacheProvider._()
       : super(
           from: null,
           argument: null,
@@ -77,34 +77,33 @@ final class FavoriteIdsCacheProvider
   FavoriteIdsCache create() => FavoriteIdsCache();
 }
 
-String _$favoriteIdsCacheHash() => r'6d9b76398c88e8734def2b30944d92564c8a068b';
+String _$favoriteIdsCacheHash() => r'e0be5972a5d472774a40ece494577d1f7c65d63b';
 
 abstract class _$FavoriteIdsCache extends $AsyncNotifier<Set<int>> {
   FutureOr<Set<int>> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<AsyncValue<Set<int>>, Set<int>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Set<int>>, Set<int>>,
         AsyncValue<Set<int>>,
         Object?,
         Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }
 
 /// ボタン連打防止を管理するProvider
 
 @ProviderFor(AbleChangeFavorite)
-const ableChangeFavoriteProvider = AbleChangeFavoriteProvider._();
+final ableChangeFavoriteProvider = AbleChangeFavoriteProvider._();
 
 /// ボタン連打防止を管理するProvider
 final class AbleChangeFavoriteProvider
     extends $NotifierProvider<AbleChangeFavorite, bool> {
   /// ボタン連打防止を管理するProvider
-  const AbleChangeFavoriteProvider._()
+  AbleChangeFavoriteProvider._()
       : super(
           from: null,
           argument: null,
@@ -141,20 +140,19 @@ abstract class _$AbleChangeFavorite extends $Notifier<bool> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<bool, bool>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<bool, bool>, bool, Object?, Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }
 
 @ProviderFor(UserIsFavoriteState)
-const userIsFavoriteStateProvider = UserIsFavoriteStateFamily._();
+final userIsFavoriteStateProvider = UserIsFavoriteStateFamily._();
 
 final class UserIsFavoriteStateProvider
     extends $AsyncNotifierProvider<UserIsFavoriteState, bool> {
-  const UserIsFavoriteStateProvider._(
+  UserIsFavoriteStateProvider._(
       {required UserIsFavoriteStateFamily super.from,
       required int super.argument})
       : super(
@@ -191,13 +189,13 @@ final class UserIsFavoriteStateProvider
 }
 
 String _$userIsFavoriteStateHash() =>
-    r'f2756f3f96e88d606957700f9a7be88d089bf311';
+    r'1f161d6fc02cc4f2d6228e21a227bebf14d2d9a3';
 
 final class UserIsFavoriteStateFamily extends $Family
     with
         $ClassFamilyOverride<UserIsFavoriteState, AsyncValue<bool>, bool,
             FutureOr<bool>, int> {
-  const UserIsFavoriteStateFamily._()
+  UserIsFavoriteStateFamily._()
       : super(
           retry: null,
           name: r'userIsFavoriteStateProvider',
@@ -225,26 +223,27 @@ abstract class _$UserIsFavoriteState extends $AsyncNotifier<bool> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build(
-      _$args,
-    );
     final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<bool>, bool>,
         AsyncValue<bool>,
         Object?,
         Object?>;
-    element.handleValue(ref, created);
+    element.handleCreate(
+        ref,
+        () => build(
+              _$args,
+            ));
   }
 }
 
 @ProviderFor(searchedHistory)
-const searchedHistoryProvider = SearchedHistoryFamily._();
+final searchedHistoryProvider = SearchedHistoryFamily._();
 
 final class SearchedHistoryProvider extends $FunctionalProvider<
         AsyncValue<List<Searched>?>, List<Searched>?, FutureOr<List<Searched>?>>
     with $FutureModifier<List<Searched>?>, $FutureProvider<List<Searched>?> {
-  const SearchedHistoryProvider._(
+  SearchedHistoryProvider._(
       {required SearchedHistoryFamily super.from, required bool super.argument})
       : super(
           retry: null,
@@ -290,11 +289,11 @@ final class SearchedHistoryProvider extends $FunctionalProvider<
   }
 }
 
-String _$searchedHistoryHash() => r'73fc7538c5477eef98cc6742da99d5c74c9700af';
+String _$searchedHistoryHash() => r'e14c7c6b4066773ed0d4719a59ba143ed4b306bb';
 
 final class SearchedHistoryFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<Searched>?>, bool> {
-  const SearchedHistoryFamily._()
+  SearchedHistoryFamily._()
       : super(
           retry: null,
           name: r'searchedHistoryProvider',
@@ -313,11 +312,11 @@ final class SearchedHistoryFamily extends $Family
 }
 
 @ProviderFor(HistoryController)
-const historyControllerProvider = HistoryControllerProvider._();
+final historyControllerProvider = HistoryControllerProvider._();
 
 final class HistoryControllerProvider
     extends $NotifierProvider<HistoryController, void> {
-  const HistoryControllerProvider._()
+  HistoryControllerProvider._()
       : super(
           from: null,
           argument: null,
@@ -344,27 +343,26 @@ final class HistoryControllerProvider
   }
 }
 
-String _$historyControllerHash() => r'56f12497211c6200902c5cab557b7b0a7b0f6ee6';
+String _$historyControllerHash() => r'a86dc22a9a7a032448198a027fbb201896d5ad80';
 
 abstract class _$HistoryController extends $Notifier<void> {
   void build();
   @$mustCallSuper
   @override
   void runBuild() {
-    build();
     final ref = this.ref as $Ref<void, void>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<void, void>, void, Object?, Object?>;
-    element.handleValue(ref, null);
+    element.handleCreate(ref, build);
   }
 }
 
 @ProviderFor(PdfCacheController)
-const pdfCacheControllerProvider = PdfCacheControllerProvider._();
+final pdfCacheControllerProvider = PdfCacheControllerProvider._();
 
 final class PdfCacheControllerProvider
     extends $NotifierProvider<PdfCacheController, void> {
-  const PdfCacheControllerProvider._()
+  PdfCacheControllerProvider._()
       : super(
           from: null,
           argument: null,
@@ -399,21 +397,20 @@ abstract class _$PdfCacheController extends $Notifier<void> {
   @$mustCallSuper
   @override
   void runBuild() {
-    build();
     final ref = this.ref as $Ref<void, void>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<void, void>, void, Object?, Object?>;
-    element.handleValue(ref, null);
+    element.handleCreate(ref, build);
   }
 }
 
 @ProviderFor(pdf)
-const pdfProvider = PdfFamily._();
+final pdfProvider = PdfFamily._();
 
 final class PdfProvider extends $FunctionalProvider<AsyncValue<Uint8List?>,
         Uint8List?, FutureOr<Uint8List?>>
     with $FutureModifier<Uint8List?>, $FutureProvider<Uint8List?> {
-  const PdfProvider._(
+  PdfProvider._(
       {required PdfFamily super.from,
       required (
         String,
@@ -477,7 +474,7 @@ final class PdfFamily extends $Family
               String,
               EnterYear,
             )> {
-  const PdfFamily._()
+  PdfFamily._()
       : super(
           retry: null,
           name: r'pdfProvider',
@@ -500,12 +497,12 @@ final class PdfFamily extends $Family
 }
 
 @ProviderFor(teacherPdf)
-const teacherPdfProvider = TeacherPdfFamily._();
+final teacherPdfProvider = TeacherPdfFamily._();
 
 final class TeacherPdfProvider extends $FunctionalProvider<
         AsyncValue<Uint8List?>, Uint8List?, FutureOr<Uint8List?>>
     with $FutureModifier<Uint8List?>, $FutureProvider<Uint8List?> {
-  const TeacherPdfProvider._(
+  TeacherPdfProvider._(
       {required TeacherPdfFamily super.from, required String super.argument})
       : super(
           retry: null,
@@ -554,7 +551,7 @@ String _$teacherPdfHash() => r'057e15f2884799ab0241d6aacd45317bb29b587f';
 
 final class TeacherPdfFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<Uint8List?>, String> {
-  const TeacherPdfFamily._()
+  TeacherPdfFamily._()
       : super(
           retry: null,
           name: r'teacherPdfProvider',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,7 +41,7 @@ Future<void> main() async {
 
   await Supabase.initialize(
     url: supabaseUrl,
-    anonKey: supabaseAnonKey,
+    publishableKey: supabaseAnonKey,
   );
 
   final sharedPreferences = await SharedPreferences.getInstance();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:ui';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -12,6 +11,7 @@ import 'package:kenryo_tankyu/core/router/router.dart';
 import 'package:kenryo_tankyu/core/theme/theme.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:kenryo_tankyu/core/providers/shared_preferences_provider.dart';
+import 'package:kenryo_tankyu/core/services/firebase_tracking_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart';
@@ -20,22 +20,13 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // グローバルエラーハンドラーの設定
-  FlutterError.onError = (FlutterErrorDetails details) {
-    debugPrint('FlutterError: ${details.exception}');
-    debugPrintStack(stackTrace: details.stack);
-  };
-
-  PlatformDispatcher.instance.onError = (Object error, StackTrace stackTrace) {
-    debugPrint('PlatformError: $error');
-    debugPrintStack(stackTrace: stackTrace);
-    return true;
-  };
-
   // 依存性の事前初期化 (Strict Initialization)
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+
+  // Crashlytics / Analytics の初期化 (グローバルエラーハンドラーを含む)
+  await FirebaseTrackingService.initialize();
 
   await dotenv.load(fileName: 'assets/.env');
 

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -1,5 +1,3 @@
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -99,11 +97,6 @@ class _HomePageState extends ConsumerState<HomePage> {
               },
             ),
             const SizedBox(height: 16),
-            if (kDebugMode)
-              TextButton(
-                onPressed: () => FirebaseCrashlytics.instance.crash(),
-                child: const Text('Throw Test Exception'),
-              ),
           ],
         ),
       ),

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -97,6 +98,11 @@ class _HomePageState extends ConsumerState<HomePage> {
               },
             ),
             const SizedBox(height: 16),
+            if (kDebugMode)
+              TextButton(
+                onPressed: () => throw Exception('Crashlytics test exception'),
+                child: const Text('Throw Test Exception'),
+              ),
           ],
         ),
       ),

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -100,7 +101,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             const SizedBox(height: 16),
             if (kDebugMode)
               TextButton(
-                onPressed: () => throw Exception('Crashlytics test exception'),
+                onPressed: () => FirebaseCrashlytics.instance.crash(),
                 child: const Text('Throw Test Exception'),
               ),
           ],

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,8 +9,10 @@ import app_links
 import cloud_firestore
 import connectivity_plus
 import dynamic_color
+import firebase_analytics
 import firebase_auth
 import firebase_core
+import firebase_crashlytics
 import firebase_messaging
 import firebase_storage
 import google_sign_in_ios
@@ -25,8 +27,10 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
+  FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,66 +21,66 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "8a1f5f3020ef2a74fb93f7ab3ef127a8feea33a7a2276279113660784ee7516a"
+      sha256: "0d1f0adfabbab9f46a1a80ce84a4d8b852b6e4dbf53ce413b30e0cf7d3631b71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.64"
+    version: "1.3.72"
   algolia_client_core:
     dependency: transitive
     description:
       name: algolia_client_core
-      sha256: cffb099e46172839b6e50bf197d8bd4ff14903d763b2e3abaa4e2f779f311c54
+      sha256: "027c481a826fef3693a9374d4275bc89b1595f4e065915760512316910ce74cb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.40.0"
+    version: "1.49.2"
   algolia_client_insights:
     dependency: transitive
     description:
       name: algolia_client_insights
-      sha256: "47ee6ac41cf2bbc2afb3f197b86693e3794372019dc20c35213b285b35898ed1"
+      sha256: "6ec022b7bf41f00fcce7146baaa2f002e48459c1d566a56928f63a27ae46c349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.40.0"
+    version: "1.49.2"
   algolia_client_search:
     dependency: transitive
     description:
       name: algolia_client_search
-      sha256: "48ca6a5c07ba3a6d9148dda1c0dc29ec52868d95fcf62d0202a8610355d688a2"
+      sha256: "97872b4c487e204b0ee7d58229e82f4f79f4123ec42d21aaa7c0ce590fcf1248"
       url: "https://pub.dev"
     source: hosted
-    version: "1.40.0"
+    version: "1.49.2"
   algolia_helper_flutter:
     dependency: "direct main"
     description:
       name: algolia_helper_flutter
-      sha256: e4085ebb0c186d065ea986d76ab32d5c314db721adb534bc5887ed51183444b7
+      sha256: "4add0a73f476bbac3204ae1ffbb5e66f73cdaf6ae6496038256d9c56d970a7d9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.6.0"
   algolia_insights:
     dependency: transitive
     description:
       name: algolia_insights
-      sha256: "1b052971675eed7519e9ccf393d658513c6d5e5b520e12190cae6d3fcc624101"
+      sha256: "2d94aecfee207e8c0cb403ec9cdcf98baacdfa89054d5f2a26fbca87f358e0b4"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   algoliasearch:
     dependency: "direct main"
     description:
       name: algoliasearch
-      sha256: "3b5c1f30e9e829ac98e30e8a437c4a0986382ef8646700749f1e0c5abf8b267a"
+      sha256: "76e64c5582f30c63f9771c3888d81b3a514222765e3b88ceec3f808e677f8431"
       url: "https://pub.dev"
     source: hosted
-    version: "1.40.0"
+    version: "1.49.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c
+      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.0"
+    version: "7.7.1"
   analyzer_buffer:
     dependency: transitive
     description:
@@ -89,14 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.10"
-  analyzer_plugin:
-    dependency: transitive
-    description:
-      name: analyzer_plugin
-      sha256: a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.13.4"
   ansicolor:
     dependency: transitive
     description:
@@ -141,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -157,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -189,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "409002f1adeea601018715d613115cfaf0e31f512cb80ae4534c79867ae2363d"
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.1.1"
   build_resolvers:
     dependency: transitive
     description:
@@ -229,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.12.6"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -261,10 +253,10 @@ packages:
     dependency: "direct main"
     description:
       name: carousel_slider
-      sha256: bcc61735345c9ab5cb81073896579e735f81e35fd588907a393143ea986be8ff
+      sha256: febf4b0163e0242adc13d7a863b04965351f59e7dfea56675c7c2caa7bcd7476
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "5.1.2"
   characters:
     dependency: transitive
     description:
@@ -309,34 +301,34 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: fc1de79a62fe21615e9012f396070e6121838ef0d879475a4ec8320e79378208
+      sha256: df9a5377365860699a96b1810a5bb37ef56db43f8e250e9f758a520f8bf8625a
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.5.0"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "2d2ee96a32ec3dd22fb682295e9bed6336e49a43f056d7841690228adca3ee7d"
+      sha256: "26e3c7f192c6b58d95d69d006f5abb722a7df11835568473438a8631041b7468"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.4"
+    version: "8.0.2"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: "28c39f3d050bf669787ef13fa0890df2b4af236de864e2db0cc3897b857066cb"
+      sha256: "0cdc8205feb73a779730782f885aaa8c23fa2e02ab57caec6076bbdcef473a41"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.5.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -349,18 +341,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.1.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   convert:
     dependency: transitive
     description:
@@ -405,26 +397,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
-  custom_lint_core:
-    dependency: transitive
-    description:
-      name: custom_lint_core
-      sha256: cc4684d22ca05bf0a4a51127e19a8aea576b42079ed2bc9e956f11aaebe35dd1
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.0"
-  custom_lint_visitor:
-    dependency: transitive
-    description:
-      name: custom_lint_visitor
-      sha256: "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0+7.7.0"
+    version: "1.0.9"
   dart_jsonwebtoken:
     dependency: transitive
     description:
@@ -445,26 +421,26 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.14"
   dio:
     dependency: transitive
     description:
       name: dio
-      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.0"
+    version: "5.9.2"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   dynamic_color:
     dependency: "direct main"
     description:
@@ -477,10 +453,10 @@ packages:
     dependency: "direct main"
     description:
       name: equatable
-      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   external_path:
     dependency: "direct main"
     description:
@@ -501,10 +477,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -513,102 +489,142 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  firebase_analytics:
+    dependency: "direct main"
+    description:
+      name: firebase_analytics
+      sha256: "1f68d8a30265149035e9bb0b73962e43f3bf2debef4a7ae2d1d588361d5858a9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.4.2"
+  firebase_analytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_analytics_platform_interface
+      sha256: "65f97fb923f036d487aa95be99eab90e0f8f636e4783c94deeb52c0e6f5dbae7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
+  firebase_analytics_web:
+    dependency: transitive
+    description:
+      name: firebase_analytics_web
+      sha256: ec49a95c6abaadbd6a4327cc2680d911f86e62fdf6f2c96a3a326603410e2abf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.1+8"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: e54fb3ba57de041d832574126a37726eedf0f57400869f1942b0ca8ce4a6e209
+      sha256: "9905a315f1235a649e29df19b246adde7350a11234837cd605254b8e25144711"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.5.2"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "421f95dc553cb283ed9d4d140e719800c0331d49ed37b962e513c9d1d61b090b"
+      sha256: f757dc5636ce2b204a82383f7246ef0d9c925f9e96c8c9a4a6c315d673d662bb
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.4"
+    version: "9.0.2"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: a064ffee202f7d42d62e2c01775899d4ffcb83c602af07632f206acd46a0964e
+      sha256: "1c44330eef3c82068e0c2919b6b015897d49211dcccdf64f90a2ed73ce216ecb"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.2.2"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "1f2dfd9f535d81f8b06d7a50ecda6eac1e6922191ed42e09ca2c84bd2288927c"
+      sha256: ec46a100a560d3bd5f97f2d89ba7492cb09b6dd0a4a28753d1258f360d6bd9f9
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "4.10.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: cccb4f572325dc14904c02fcc7db6323ad62ba02536833dddb5c02cac7341c64
+      sha256: "4a120366dbf7d5a8ee9438978530b664b855728fb8dcc3a201017660817e555b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: ff18fabb0ad0ed3595d2f2c85007ecc794aadecdff5b3bb1460b7ee47cded398
+      sha256: "5ad1be848692ec148f2d6a8ad2a3838cb852ea5f3c9e6479a7afce479e1854f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.8.0"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      sha256: "5d111db2b40426e76e2da95d133c19a9dbcf6500c4e9b3785c68da51fb3f6602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.3"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      sha256: "5bf4a83a1b9e0a5218f6d6491227440dd659242a55b16c279de0b8839791539a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.23"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "22086f857d2340f5d973776cfd542d3fb30cf98e1c643c3aa4a7520bb12745bb"
+      sha256: "9651e833454156b9f0927eaedccffba0f7f6a6e20ceddef82517211e7017e9c4"
       url: "https://pub.dev"
     source: hosted
-    version: "16.0.4"
+    version: "16.3.0"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: a59920cbf2eb7c83d34a5f354331210ffec116b216dc72d864d8b8eb983ca398
+      sha256: "292bb5dc9c4a429078895406c347d7c7690deb858c1adeed8f4b4346f769dfa3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.4"
+    version: "4.8.0"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "1183e40e6fd2a279a628951cc3b639fcf5ffe7589902632db645011eb70ebefb"
+      sha256: "08c565bc83729439f5de2dfea77b4832002b705eb2f840366cefa80e4e5c3c66"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
-      sha256: "3438f38590186010ce76ece683ebf3b842cd637f31f83a13620917d7438a58fd"
+      sha256: "540a2eb9b622ad7a173809a215ba3b2ba2a7a56a88d35dd7d9f392abeec45dbf"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.4"
+    version: "13.4.2"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
-      sha256: "5d56021a9d30f7ca89559c96cc4c7250ce6ff8881382ff7238fde64a1f449e39"
+      sha256: f5fd1181f6cc7dcf7ea85fddb8ce32a0e8ebf09a1dfe3c70c4ae7e540cb57be3
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.15"
+    version: "6.0.2"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
-      sha256: a06775d1df6dd90f5fa3fe9e221b988dcbc221e73a0f8951136536e6d5e548e6
+      sha256: a4387d657b09dfa1bcd52d3a1ba276b5a22b3f5dffa9fce8a0e0bd8aa734d43f
       url: "https://pub.dev"
     source: hosted
-    version: "3.11.0"
+    version: "3.11.8"
   fixnum:
     dependency: transitive
     description:
@@ -634,10 +650,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_dotenv
-      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
+      sha256: d41da11fb497314fbf89811ec30af02d1d898b47980a129f0a8c0a1720460ba2
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "6.0.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -674,18 +690,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_pdfview
-      sha256: c0b2cc4ebf461a5a4bb9312a165222475a7d93845c7a0703f4abb7f442eb6d54
+      sha256: "5b80e89f3ba6e478d1e897543c9634508284ad73476807febc188378986b69ee"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.3"
+    version: "1.4.4"
   flutter_riverpod:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9e2d6907f12cc7d23a846847615941bddee8709bf2bfd274acdf5e80bcf22fde"
+      sha256: "38ec6c303e2c83ee84512f5fc2a82ae311531021938e63d7137eccc107bf3c02"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.1.0"
   flutter_screenutil:
     dependency: "direct main"
     description:
@@ -732,10 +748,10 @@ packages:
     dependency: transitive
     description:
       name: functions_client
-      sha256: "94074d62167ae634127ef6095f536835063a7dc80f2b1aa306d2346ff9023996"
+      sha256: "94bde5b8062b1c498795ce509cbe7e83417e171eb55c2c611da64c15034b7851"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   glob:
     dependency: transitive
     description:
@@ -748,10 +764,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: d8f590a69729f719177ea68eb1e598295e8dbc41bbc247fed78b2c8a25660d7c
+      sha256: "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f"
       url: "https://pub.dev"
     source: hosted
-    version: "16.3.0"
+    version: "17.2.3"
   go_router_builder:
     dependency: "direct dev"
     description:
@@ -780,18 +796,18 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: "7a0d3b7e73e21d88612ebbb1942e91ee1eb35ed3086b1a0a3398b2248be29034"
+      sha256: df5c15533814ed20b7d9e1c5a40a73f174e5d5017bd2669b1c72fb6596fde812
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.2"
+    version: "7.2.11"
   google_sign_in_ios:
     dependency: transitive
     description:
       name: google_sign_in_ios
-      sha256: "0ba0b276c91e80edbe28570ee8c54237c095dd7b909db46011154a49f3af68a7"
+      sha256: "234fc2830b55d1bbeb7e05662967691f5994143ff43dc70d3f139d1bbb3b8fb2"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.3"
+    version: "6.2.5"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
@@ -804,18 +820,18 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_web
-      sha256: "2fc1f941e6443b2d6984f4056a727a3eaeab15d8ee99ba7125d79029be75a1da"
+      sha256: d473003eeca892f96a01a64fc803378be765071cb0c265ee872c7f8683245d14
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.3"
   googleapis:
     dependency: "direct main"
     description:
       name: googleapis
-      sha256: "692fb9e90c321b61a7a2123de0353ec8a20691cd979db2553d8d732f710f6535"
+      sha256: "62b5988f228b774448ebd99b53fe8069becb55840f1b28948bb84160373dc0b6"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "16.0.0"
   googleapis_auth:
     dependency: "direct main"
     description:
@@ -828,10 +844,10 @@ packages:
     dependency: transitive
     description:
       name: gotrue
-      sha256: "7a4172601553e61716f5c3dd243aa3297e13308e07eb85b7853c941ba585dcf5"
+      sha256: "22f0a6ea86c8024de6b164a49a213cfa60a23f19df26e5bca8d6eb7e087fdf17"
       url: "https://pub.dev"
     source: hosted
-    version: "2.20.0"
+    version: "2.21.0"
   graphs:
     dependency: transitive
     description:
@@ -876,10 +892,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -900,10 +916,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.4"
+    version: "4.8.0"
   io:
     dependency: transitive
     description:
@@ -932,10 +948,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
+      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.1"
+    version: "6.11.2"
   jwt_decode:
     dependency: transitive
     description:
@@ -972,10 +988,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   logging:
     dependency: transitive
     description:
@@ -1076,18 +1092,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: e122c5ea805bb6773bb12ce667611265980940145be920cd09a4b0ec0285cb16
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.20"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: efaec349ddfc181528345c56f8eda9d6cccd71c177511b132c6a0ddaefaa2738
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.5.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1116,10 +1132,10 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.3"
   permission_handler_android:
     dependency: transitive
     description:
@@ -1132,10 +1148,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.7"
+    version: "9.4.9"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1164,10 +1180,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -1204,10 +1220,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.5.0"
   postgrest:
     dependency: transitive
     description:
@@ -1252,34 +1268,34 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: c406de02bff19d920b832bddfb8283548bfa05ce41c59afba57ce643e116aa59
+      sha256: "16ff608d21e8ea64364f2b7c049c94a02ab81668f78845862b6e88b71dd4935a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.1.0"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: a0f68adb078b790faa3c655110a017f9a7b7b079a57bbd40f540e80dce5fcd29
+      sha256: "947b05d04c52a546a2ac6b19ef2a54b08520ff6bdf9f23d67957a4c8df1c3bc0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.7"
+    version: "1.0.0-dev.8"
   riverpod_annotation:
     dependency: transitive
     description:
       name: riverpod_annotation
-      sha256: "7230014155777fc31ba3351bc2cb5a3b5717b11bfafe52b1553cb47d385f8897"
+      sha256: cc1474bc2df55ec3c1da1989d139dcef22cd5e2bd78da382e867a69a8eca2e46
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "4.0.0"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "49894543a42cf7a9954fc4e7366b6d3cb2e6ec0fa07775f660afcdd92d097702"
+      sha256: e43b1537229cc8f487f09b0c20d15dba840acbadcf5fc6dad7ad5e8ab75950dc
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "4.0.0+1"
   rxdart:
     dependency: transitive
     description:
@@ -1324,26 +1340,26 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "34266009473bf71d748912da4bf62d439185226c03e01e2d9687bc65bbfcb713"
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.4.23"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "1c33a907142607c40a7542768ec9badfd16293bac51da3a4482623d15845f88b"
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.5.6"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1356,10 +1372,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -1457,10 +1473,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   sqflite:
     dependency: "direct main"
     description:
@@ -1521,10 +1537,10 @@ packages:
     dependency: transitive
     description:
       name: storage_client
-      sha256: "4801e8ca219a35e51cbb30589aba5306667ae8935b792504595a45273cef0b18"
+      sha256: c108351e9811f4c47afce1147ed3daef7f7647d095884101af16ad79bb2a8e9f
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.4"
   stream_channel:
     dependency: transitive
     description:
@@ -1553,18 +1569,18 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: "40e5a8833c8834e140ef53b60a6181849667eba9ca125acb7f8e24c6a769d418"
+      sha256: "3eeddc8fd654360aa4105e6d28ef5d027687bb40bfcffd9b1f2814640862bc91"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.6"
+    version: "2.12.0"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
-      sha256: c02ce58abcaf86cb8055ad40bfd98bbf5b93fed3b5b56b8220d88ed03842818b
+      sha256: cc1646a1be4c2c204ec078141e44b352228b72a7074124b756a712b0762398ec
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.4"
+    version: "2.14.0"
   synchronized:
     dependency: transitive
     description:
@@ -1625,10 +1641,10 @@ packages:
     dependency: transitive
     description:
       name: universal_io
-      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      sha256: f63cbc48103236abf48e345e07a03ce5757ea86285ed313a6a032596ed9301e2
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.3.1"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1641,34 +1657,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "5c8b6c2d89a78f5a1cca70a73d9d5f86c701b36b42f9c9dac7bad592113c28e9"
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.24"
+    version: "6.3.29"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "6b63f1441e4f653ae799166a72b50b1767321ecc263a57aadf825a7a2a5477d9"
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.5"
+    version: "6.3.6"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "8262208506252a3ed4ff5c0dc1e973d2c0e0ef337d0a074d35634da5d44397c9"
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.4"
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1689,18 +1705,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:
@@ -1713,18 +1729,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  go_router: ^16.3.0
+  go_router: ^17.2.3
   flutter_riverpod: ^3.0.3
   firebase_core: ^4.2.1
   firebase_messaging: ^16.0.4
@@ -44,6 +44,8 @@ dependencies:
   google_sign_in: ^7.2.0
   equatable: ^2.0.5
   firebase_storage: ^13.0.4
+  firebase_crashlytics: ^5.2.3
+  firebase_analytics: ^12.4.2
   cached_network_image: ^3.3.1
   freezed_annotation: ^3.1.0
   path_provider: ^2.1.2
@@ -54,7 +56,7 @@ dependencies:
   external_path: ^2.2.0
   json_annotation: ^4.9.0
   shared_preferences: ^2.2.3
-  googleapis: ^15.0.0
+  googleapis: ^16.0.0
   googleapis_auth: ^2.0.0
   flutter_pdfview: ^1.3.2
   screenshot_callback: ^3.0.1
@@ -69,7 +71,7 @@ dependencies:
   connectivity_plus: ^7.0.0
   share_plus: ^12.0.2
   supabase_flutter: ^2.8.4
-  flutter_dotenv: ^5.2.1
+  flutter_dotenv: ^6.0.1
 
 dev_dependencies:
   flutter_test:
@@ -84,7 +86,7 @@ dev_dependencies:
   freezed: ^3.2.3
   build_runner: ^2.4.8
   json_serializable: ^6.7.1
-  riverpod_generator: ^3.0.3
+  riverpod_generator: ^4.0.0+1
   flutter_native_splash: ^2.3.10
   flutter_launcher_icons: ^0.14.2
   go_router_builder: ^4.1.1


### PR DESCRIPTION
## 概要
Firebase Crashlytics と Firebase Analytics を導入し、アプリのエラーを正確に収集できる仕組みを構築した。

## 種別
- [x] 機能追加

## 関連Issue
Closes #177

## 変更内容
- `firebase_crashlytics` / `firebase_analytics` を依存関係に追加
- `lib/core/services/firebase_tracking_service.dart` を新設
  - `initialize()`: Crashlytics の有効化 + Flutter/PlatformDispatcher のグローバルエラーハンドラを登録（releaseビルドのみ有効）
  - `logPdfNotFound()`: PDF が Storage に存在しない場合に `documentId` と `pdfPath` を Crashlytics ログ + Analytics イベントとして記録
  - `logAuthFailure()`: ログイン失敗時に `method` と `errorCode` を記録
  - `recordError()`: 任意の非致命的エラーを Crashlytics へ送信
- `main.dart`: 既存の `debugPrint` のみのエラーハンドラを `FirebaseTrackingService.initialize()` に置き換え
- `display_pdf.dart`: PDF `object-not-found` エラー時と一般エラー時に Crashlytics へ記録
- `auth_repository_impl.dart`: `signInWithEmailAndPassword` / `createUserWithEmailAndPassword` の `FirebaseAuthException` キャッチ時にログを送信

## スクリーンショット
なし（ログ・バックエンド側の変更）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）