### PR TITLE
[fix] ログインしても「ゲスト」のまま (#188)

### DIFF
--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -31,7 +31,8 @@ class _HomePageState extends ConsumerState<HomePage> {
   Widget build(BuildContext context) {
     final profileName = developer_mode
         ? 'ゲスト'
-        : ref.watch(authStateChangesProvider).asData?.value?.displayName ?? 'ゲスト';
+        : ref.watch(authStateChangesProvider).asData?.value?.displayName ??
+            'ゲスト';
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: SingleChildScrollView(

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import "package:kenryo_tankyu/core/constants/app_unique_value.dart";
 import 'package:kenryo_tankyu/features/search/presentation/widgets/result_preview_content.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
-import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_repository_provider.dart';
+import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
 import 'package:kenryo_tankyu/presentation/widget/error_view.dart';
 import 'package:kenryo_tankyu/presentation/widget/startup_dialogs.dart';
 
@@ -31,7 +31,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   Widget build(BuildContext context) {
     final profileName = developer_mode
         ? 'ゲスト'
-        : ref.watch(authRepositoryProvider).currentUser?.displayName ?? 'ゲスト';
+        : ref.watch(authStateChangesProvider).asData?.value?.displayName ?? 'ゲスト';
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: SingleChildScrollView(


### PR DESCRIPTION
## 概要

ログイン後も `home_page.dart` でユーザー名が「ゲスト」のままになっていた問題を修正。

## 原因

`ref.watch(authRepositoryProvider).currentUser?.displayName` という実装では、`authRepositoryProvider` は `AuthRepository` インスタンスを返すだけのProviderであり、Firebase Authの状態変化を監視しない。そのため、ログイン後にdisplayNameが設定されても再ビルドされず「ゲスト」が表示され続けていた。

## 修正内容

`authStateChangesProvider`（Firebase Auth のストリームを監視するProvider）を `watch` するよう変更。
Auth状態が変化するたびにWidgetが再ビルドされ、最新の `displayName` を取得できるようになった。

```dart
// Before
ref.watch(authRepositoryProvider).currentUser?.displayName ?? 'ゲスト'

// After
ref.watch(authStateChangesProvider).asData?.value?.displayName ?? 'ゲスト'
```

## 動作確認チェックリスト

- [ ] ログイン後にホーム画面でユーザー名が正しく表示される
- [ ] ログアウト後は「ゲスト」に戻る

## 関連

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)