### PR TITLE
[UserArchive/DisplayPdf] レビュー指摘の2点を修正

### DIFF
--- a/lib/features/research_work/presentation/widgets/display_pdf.dart
+++ b/lib/features/research_work/presentation/widgets/display_pdf.dart
@@ -23,6 +23,24 @@ class DisplayPdf extends ConsumerWidget {
             final pdfAsync =
                 ref.watch(pdfProvider(nowWatchingPdf, searched.enterYear));
 
+            // ログはbuild外で一度だけ送出する
+            ref.listen(pdfProvider(nowWatchingPdf, searched.enterYear),
+                (previous, next) {
+              if (previous?.hasError == true) return;
+              next.whenOrNull(error: (error, stack) {
+                if (error is ServerFailure &&
+                    error.code == 'object-not-found') {
+                  FirebaseTrackingService.logPdfNotFound(
+                    documentId: searched.documentID,
+                    pdfPath: nowWatchingPdf,
+                  );
+                } else {
+                  FirebaseTrackingService.recordError(error, stack,
+                      reason: 'pdf_load_error');
+                }
+              });
+            });
+
             return pdfAsync.when(
               data: (pdfData) {
                 if (pdfData == null) {
@@ -60,10 +78,6 @@ class DisplayPdf extends ConsumerWidget {
               error: (error, stack) {
                 if (error is ServerFailure &&
                     error.code == 'object-not-found') {
-                  FirebaseTrackingService.logPdfNotFound(
-                    documentId: searched.documentID,
-                    pdfPath: nowWatchingPdf,
-                  );
                   return const CommonErrorView(
                     error: ServerFailure(
                       message: 'ファイルが見つかりませんでした',
@@ -71,8 +85,6 @@ class DisplayPdf extends ConsumerWidget {
                     ),
                   );
                 }
-                FirebaseTrackingService.recordError(error, stack,
-                    reason: 'pdf_load_error');
                 return CommonErrorView(
                   error: error,
                   onRetry: () => ref.invalidate(

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.dart
@@ -181,8 +181,30 @@ class SearchedHistoryNotifier extends _$SearchedHistoryNotifier {
     _hasMore = true;
     _isFetchingMore = false;
 
-    // お気に入りIDキャッシュが揃うまで待機
-    final favoriteIds = await ref.watch(favoriteIdsCacheProvider.future);
+    // お気に入り変更をインプレース更新（ref.watchにするとリスト全体がリセットされる）
+    ref.listen(favoriteIdsCacheProvider, (previous, next) {
+      final favoriteIds = next.asData?.value;
+      if (favoriteIds == null) return;
+      final current = state.asData?.value;
+      if (current == null) return;
+      if (onlyShowFavorite) {
+        state = AsyncData(
+          current
+              .where((item) => favoriteIds.contains(item.documentID))
+              .toList(),
+        );
+      } else {
+        state = AsyncData(
+          current
+              .map((item) => item.copyWith(
+                  isFavorite: favoriteIds.contains(item.documentID)))
+              .toList(),
+        );
+      }
+    });
+
+    // 初回のみ読み取る（再ビルドを防ぐためreadを使用）
+    final favoriteIds = await ref.read(favoriteIdsCacheProvider.future);
 
     final items = await _fetchPage(0, favoriteIds);
     _hasMore = items.length == _pageSize;


### PR DESCRIPTION
## 概要
PR #195 のGeminiレビューで指摘されたバグ2件を修正する。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #  

## 変更内容

### バグ修正1: 無限スクロールリストがお気に入り変更のたびにリセットされる

**ファイル**: `user_archive_providers.dart` — `SearchedHistoryNotifier.build`

`ref.watch(favoriteIdsCacheProvider.future)` を使っていたため、お気に入りの追加・削除が発生するたびに `build` が再実行され、読み込み済みのページが全消えして最初の20件に戻るUXバグがあった。

`ref.read` で初回のみ取得し、その後の変更は `ref.listen` でインプレース更新するよう修正。

### バグ修正2: buildフェーズ内でのFirebase側副作用（ログ送出）

**ファイル**: `display_pdf.dart` — `DisplayPdf.build`

`pdfAsync.when(error:)` コールバック内で `FirebaseTrackingService.logPdfNotFound` / `recordError` を直接呼んでいたため、Widgetが別の理由で再ビルドされるたびに重複送出されるリスクがあった。

`ref.listen` で状態遷移時のみ一度だけ送出するよう修正。

### Google Sign-In（変更なし）

レビューでは `GoogleSignIn.instance.authenticate()` や `GoogleSignInException` が存在しないと指摘されていたが、これらはv7.0.0で追加されたAPIであり、現在使用している v7.2.0 に正しく存在するため修正不要。

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）