### PR TITLE
ホーム画面に閲覧統計カードと連続閲覧ストリークを追加

### DIFF
--- a/lib/features/research_work/presentation/providers/searched_provider.dart
+++ b/lib/features/research_work/presentation/providers/searched_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:kenryo_tankyu/features/research_work/data/repositories/research_work_repository_impl.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
+import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_stats_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'searched_provider.g.dart';
@@ -36,6 +37,8 @@ class ResearchWork extends _$ResearchWork {
         ref.read(forceReloadProvider.notifier).state = false;
       }
       await archiveRepo.insertHistory(combined);
+      // 新規閲覧としてカウントをリアルタイムに反映
+      ref.read(userStatsProvider.notifier).incrementViewCount();
       return combined;
     }
 

--- a/lib/features/user_archive/data/datasources/user_stats_data_source.dart
+++ b/lib/features/user_archive/data/datasources/user_stats_data_source.dart
@@ -54,6 +54,17 @@ class UserStatsDataSource {
     return getStats(userId);
   }
 
+  /// インメモリのカウントアップに連動してキャッシュも更新する。
+  void updateCachedCounts({
+    required int todayViews,
+    required int weekViews,
+    required int totalViews,
+  }) {
+    _prefs.setInt(_keyTodayViews, todayViews);
+    _prefs.setInt(_keyWeekViews, weekViews);
+    _prefs.setInt(_keyTotalViews, totalViews);
+  }
+
   int _updateStreak() {
     final today = _todayString();
     final lastOpen = _prefs.getString(_keyLastOpenDate);
@@ -75,26 +86,27 @@ class UserStatsDataSource {
   }
 
   Future<UserStats> _fetchFromSupabase(String userId, int streak) async {
-    final now = DateTime.now().toUtc();
-    final todayStart = DateTime.utc(now.year, now.month, now.day);
+    // ローカル時間で「今日の開始」を求めてから UTC に変換（タイムゾーン対応）
+    final now = DateTime.now();
+    final todayStart = DateTime(now.year, now.month, now.day).toUtc();
     final weekStart = todayStart.subtract(const Duration(days: 7));
 
     final results = await Future.wait([
       _client
           .from('browsing_history')
-          .select()
+          .select('document_id')
           .eq('user_id', userId)
           .gte('viewed_at', todayStart.toIso8601String())
           .count(CountOption.exact),
       _client
           .from('browsing_history')
-          .select()
+          .select('document_id')
           .eq('user_id', userId)
           .gte('viewed_at', weekStart.toIso8601String())
           .count(CountOption.exact),
       _client
           .from('browsing_history')
-          .select()
+          .select('document_id')
           .eq('user_id', userId)
           .count(CountOption.exact),
     ]);
@@ -130,8 +142,11 @@ class UserStatsDataSource {
     return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
   }
 
+  // Duration(days: 1) は DST で24時間とならない場合があるため
+  // DateTime コンストラクタの自動繰り下げを使う
   String _yesterdayString() {
-    final d = DateTime.now().subtract(const Duration(days: 1));
+    final now = DateTime.now();
+    final d = DateTime(now.year, now.month, now.day - 1);
     return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
   }
 }

--- a/lib/features/user_archive/data/datasources/user_stats_data_source.dart
+++ b/lib/features/user_archive/data/datasources/user_stats_data_source.dart
@@ -1,0 +1,137 @@
+import 'package:kenryo_tankyu/core/providers/shared_preferences_provider.dart';
+import 'package:kenryo_tankyu/core/providers/supabase_provider.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/user_stats.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'user_stats_data_source.g.dart';
+
+@Riverpod(keepAlive: true)
+UserStatsDataSource userStatsDataSource(Ref ref) {
+  return UserStatsDataSource(
+    ref.watch(supabaseClientProvider),
+    ref.watch(sharedPreferencesProvider),
+  );
+}
+
+class UserStatsDataSource {
+  UserStatsDataSource(this._client, this._prefs);
+
+  final SupabaseClient _client;
+  final SharedPreferences _prefs;
+
+  static const _keyFetchedAt = 'user_stats_fetched_at';
+  static const _keyTodayViews = 'user_stats_today_views';
+  static const _keyWeekViews = 'user_stats_week_views';
+  static const _keyTotalViews = 'user_stats_total_views';
+  static const _keyStreakDays = 'user_stats_streak_days';
+  static const _keyLastOpenDate = 'user_stats_last_open_date';
+  static const _cacheHours = 1;
+
+  /// ストリークを更新してキャッシュから返す。
+  /// 閲覧件数は1時間キャッシュし、期限切れなら Supabase から再取得する。
+  Future<UserStats> getStats(String userId) async {
+    final streak = _updateStreak();
+
+    final fetchedAt = _prefs.getString(_keyFetchedAt);
+    if (fetchedAt != null) {
+      final last = DateTime.parse(fetchedAt);
+      if (DateTime.now().difference(last) <
+          const Duration(hours: _cacheHours)) {
+        return _loadFromCache(streak);
+      }
+    }
+
+    final stats = await _fetchFromSupabase(userId, streak);
+    await _saveToCache(stats);
+    return stats;
+  }
+
+  /// キャッシュを破棄して強制再取得する。
+  Future<UserStats> refreshStats(String userId) async {
+    await _prefs.remove(_keyFetchedAt);
+    return getStats(userId);
+  }
+
+  int _updateStreak() {
+    final today = _todayString();
+    final lastOpen = _prefs.getString(_keyLastOpenDate);
+    int streak = _prefs.getInt(_keyStreakDays) ?? 0;
+
+    if (lastOpen == null) {
+      streak = 1;
+    } else if (lastOpen == today) {
+      // 同日は変化なし
+    } else if (lastOpen == _yesterdayString()) {
+      streak += 1;
+    } else {
+      streak = 1;
+    }
+
+    _prefs.setString(_keyLastOpenDate, today);
+    _prefs.setInt(_keyStreakDays, streak);
+    return streak;
+  }
+
+  Future<UserStats> _fetchFromSupabase(String userId, int streak) async {
+    final now = DateTime.now().toUtc();
+    final todayStart = DateTime.utc(now.year, now.month, now.day);
+    final weekStart = todayStart.subtract(const Duration(days: 7));
+
+    final results = await Future.wait([
+      _client
+          .from('browsing_history')
+          .select()
+          .eq('user_id', userId)
+          .gte('viewed_at', todayStart.toIso8601String())
+          .count(CountOption.exact),
+      _client
+          .from('browsing_history')
+          .select()
+          .eq('user_id', userId)
+          .gte('viewed_at', weekStart.toIso8601String())
+          .count(CountOption.exact),
+      _client
+          .from('browsing_history')
+          .select()
+          .eq('user_id', userId)
+          .count(CountOption.exact),
+    ]);
+
+    return UserStats(
+      todayViews: results[0].count,
+      weekViews: results[1].count,
+      totalViews: results[2].count,
+      streakDays: streak,
+    );
+  }
+
+  UserStats _loadFromCache(int streak) {
+    return UserStats(
+      todayViews: _prefs.getInt(_keyTodayViews) ?? 0,
+      weekViews: _prefs.getInt(_keyWeekViews) ?? 0,
+      totalViews: _prefs.getInt(_keyTotalViews) ?? 0,
+      streakDays: streak,
+    );
+  }
+
+  Future<void> _saveToCache(UserStats stats) async {
+    await Future.wait([
+      _prefs.setString(_keyFetchedAt, DateTime.now().toIso8601String()),
+      _prefs.setInt(_keyTodayViews, stats.todayViews),
+      _prefs.setInt(_keyWeekViews, stats.weekViews),
+      _prefs.setInt(_keyTotalViews, stats.totalViews),
+    ]);
+  }
+
+  String _todayString() {
+    final d = DateTime.now();
+    return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+  }
+
+  String _yesterdayString() {
+    final d = DateTime.now().subtract(const Duration(days: 1));
+    return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/features/user_archive/data/datasources/user_stats_data_source.g.dart
+++ b/lib/features/user_archive/data/datasources/user_stats_data_source.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_stats_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(userStatsDataSource)
+final userStatsDataSourceProvider = UserStatsDataSourceProvider._();
+
+final class UserStatsDataSourceProvider extends $FunctionalProvider<
+    UserStatsDataSource,
+    UserStatsDataSource,
+    UserStatsDataSource> with $Provider<UserStatsDataSource> {
+  UserStatsDataSourceProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'userStatsDataSourceProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$userStatsDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<UserStatsDataSource> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  UserStatsDataSource create(Ref ref) {
+    return userStatsDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(UserStatsDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<UserStatsDataSource>(value),
+    );
+  }
+}
+
+String _$userStatsDataSourceHash() =>
+    r'd888b00c3dbe23892cfb2bbe81568cd39b85c17f';

--- a/lib/features/user_archive/domain/models/user_stats.dart
+++ b/lib/features/user_archive/domain/models/user_stats.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_stats.freezed.dart';
+part 'user_stats.g.dart';
+
+@freezed
+abstract class UserStats with _$UserStats {
+  const factory UserStats({
+    required int todayViews,
+    required int weekViews,
+    required int totalViews,
+    required int streakDays,
+  }) = _UserStats;
+
+  factory UserStats.fromJson(Map<String, dynamic> json) =>
+      _$UserStatsFromJson(json);
+}

--- a/lib/features/user_archive/domain/models/user_stats.freezed.dart
+++ b/lib/features/user_archive/domain/models/user_stats.freezed.dart
@@ -1,0 +1,380 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_stats.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$UserStats {
+  int get todayViews;
+  int get weekViews;
+  int get totalViews;
+  int get streakDays;
+
+  /// Create a copy of UserStats
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $UserStatsCopyWith<UserStats> get copyWith =>
+      _$UserStatsCopyWithImpl<UserStats>(this as UserStats, _$identity);
+
+  /// Serializes this UserStats to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is UserStats &&
+            (identical(other.todayViews, todayViews) ||
+                other.todayViews == todayViews) &&
+            (identical(other.weekViews, weekViews) ||
+                other.weekViews == weekViews) &&
+            (identical(other.totalViews, totalViews) ||
+                other.totalViews == totalViews) &&
+            (identical(other.streakDays, streakDays) ||
+                other.streakDays == streakDays));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, todayViews, weekViews, totalViews, streakDays);
+
+  @override
+  String toString() {
+    return 'UserStats(todayViews: $todayViews, weekViews: $weekViews, totalViews: $totalViews, streakDays: $streakDays)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $UserStatsCopyWith<$Res> {
+  factory $UserStatsCopyWith(UserStats value, $Res Function(UserStats) _then) =
+      _$UserStatsCopyWithImpl;
+  @useResult
+  $Res call({int todayViews, int weekViews, int totalViews, int streakDays});
+}
+
+/// @nodoc
+class _$UserStatsCopyWithImpl<$Res> implements $UserStatsCopyWith<$Res> {
+  _$UserStatsCopyWithImpl(this._self, this._then);
+
+  final UserStats _self;
+  final $Res Function(UserStats) _then;
+
+  /// Create a copy of UserStats
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? todayViews = null,
+    Object? weekViews = null,
+    Object? totalViews = null,
+    Object? streakDays = null,
+  }) {
+    return _then(_self.copyWith(
+      todayViews: null == todayViews
+          ? _self.todayViews
+          : todayViews // ignore: cast_nullable_to_non_nullable
+              as int,
+      weekViews: null == weekViews
+          ? _self.weekViews
+          : weekViews // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalViews: null == totalViews
+          ? _self.totalViews
+          : totalViews // ignore: cast_nullable_to_non_nullable
+              as int,
+      streakDays: null == streakDays
+          ? _self.streakDays
+          : streakDays // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [UserStats].
+extension UserStatsPatterns on UserStats {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_UserStats value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _UserStats() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_UserStats value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _UserStats():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_UserStats value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _UserStats() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            int todayViews, int weekViews, int totalViews, int streakDays)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _UserStats() when $default != null:
+        return $default(_that.todayViews, _that.weekViews, _that.totalViews,
+            _that.streakDays);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            int todayViews, int weekViews, int totalViews, int streakDays)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _UserStats():
+        return $default(_that.todayViews, _that.weekViews, _that.totalViews,
+            _that.streakDays);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            int todayViews, int weekViews, int totalViews, int streakDays)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _UserStats() when $default != null:
+        return $default(_that.todayViews, _that.weekViews, _that.totalViews,
+            _that.streakDays);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _UserStats implements UserStats {
+  const _UserStats(
+      {required this.todayViews,
+      required this.weekViews,
+      required this.totalViews,
+      required this.streakDays});
+  factory _UserStats.fromJson(Map<String, dynamic> json) =>
+      _$UserStatsFromJson(json);
+
+  @override
+  final int todayViews;
+  @override
+  final int weekViews;
+  @override
+  final int totalViews;
+  @override
+  final int streakDays;
+
+  /// Create a copy of UserStats
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UserStatsCopyWith<_UserStats> get copyWith =>
+      __$UserStatsCopyWithImpl<_UserStats>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$UserStatsToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _UserStats &&
+            (identical(other.todayViews, todayViews) ||
+                other.todayViews == todayViews) &&
+            (identical(other.weekViews, weekViews) ||
+                other.weekViews == weekViews) &&
+            (identical(other.totalViews, totalViews) ||
+                other.totalViews == totalViews) &&
+            (identical(other.streakDays, streakDays) ||
+                other.streakDays == streakDays));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, todayViews, weekViews, totalViews, streakDays);
+
+  @override
+  String toString() {
+    return 'UserStats(todayViews: $todayViews, weekViews: $weekViews, totalViews: $totalViews, streakDays: $streakDays)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$UserStatsCopyWith<$Res>
+    implements $UserStatsCopyWith<$Res> {
+  factory _$UserStatsCopyWith(
+          _UserStats value, $Res Function(_UserStats) _then) =
+      __$UserStatsCopyWithImpl;
+  @override
+  @useResult
+  $Res call({int todayViews, int weekViews, int totalViews, int streakDays});
+}
+
+/// @nodoc
+class __$UserStatsCopyWithImpl<$Res> implements _$UserStatsCopyWith<$Res> {
+  __$UserStatsCopyWithImpl(this._self, this._then);
+
+  final _UserStats _self;
+  final $Res Function(_UserStats) _then;
+
+  /// Create a copy of UserStats
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? todayViews = null,
+    Object? weekViews = null,
+    Object? totalViews = null,
+    Object? streakDays = null,
+  }) {
+    return _then(_UserStats(
+      todayViews: null == todayViews
+          ? _self.todayViews
+          : todayViews // ignore: cast_nullable_to_non_nullable
+              as int,
+      weekViews: null == weekViews
+          ? _self.weekViews
+          : weekViews // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalViews: null == totalViews
+          ? _self.totalViews
+          : totalViews // ignore: cast_nullable_to_non_nullable
+              as int,
+      streakDays: null == streakDays
+          ? _self.streakDays
+          : streakDays // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/features/user_archive/domain/models/user_stats.g.dart
+++ b/lib/features/user_archive/domain/models/user_stats.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_stats.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_UserStats _$UserStatsFromJson(Map<String, dynamic> json) => _UserStats(
+      todayViews: (json['todayViews'] as num).toInt(),
+      weekViews: (json['weekViews'] as num).toInt(),
+      totalViews: (json['totalViews'] as num).toInt(),
+      streakDays: (json['streakDays'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$UserStatsToJson(_UserStats instance) =>
+    <String, dynamic>{
+      'todayViews': instance.todayViews,
+      'weekViews': instance.weekViews,
+      'totalViews': instance.totalViews,
+      'streakDays': instance.streakDays,
+    };

--- a/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_archive_providers.g.dart
@@ -290,7 +290,7 @@ final class SearchedHistoryNotifierProvider
 }
 
 String _$searchedHistoryNotifierHash() =>
-    r'37c3ee308f828d86b40a468a6f1f26b68aaf40a1';
+    r'aee40e34e4689dce4913bf1699255b7542953409';
 
 /// 無限スクロール対応の閲覧履歴 / お気に入りリスト。
 /// [onlyShowFavorite] が true のときはお気に入りのみ表示する。

--- a/lib/features/user_archive/presentation/providers/user_stats_provider.dart
+++ b/lib/features/user_archive/presentation/providers/user_stats_provider.dart
@@ -25,10 +25,28 @@ class UserStatsNotifier extends _$UserStatsNotifier {
   Future<void> refresh() async {
     final user = ref.read(authStateChangesProvider).asData?.value;
     if (user == null || !user.emailVerified) return;
-    state = const AsyncLoading();
+    state = const AsyncLoading<UserStats>();
     state = await AsyncValue.guard(() async {
       final dataSource = ref.read(userStatsDataSourceProvider);
       return dataSource.refreshStats(user.uid);
     });
+  }
+
+  /// 新規閲覧時にインメモリカウントをインクリメントする。
+  /// Supabase への再フェッチなしで即時反映させる。
+  void incrementViewCount() {
+    final current = state.asData?.value;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(
+      todayViews: current.todayViews + 1,
+      weekViews: current.weekViews + 1,
+      totalViews: current.totalViews + 1,
+    ));
+    // キャッシュも更新して次回起動時に整合性を保つ
+    ref.read(userStatsDataSourceProvider).updateCachedCounts(
+          todayViews: current.todayViews + 1,
+          weekViews: current.weekViews + 1,
+          totalViews: current.totalViews + 1,
+        );
   }
 }

--- a/lib/features/user_archive/presentation/providers/user_stats_provider.dart
+++ b/lib/features/user_archive/presentation/providers/user_stats_provider.dart
@@ -1,0 +1,34 @@
+import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
+import 'package:kenryo_tankyu/features/user_archive/data/datasources/user_stats_data_source.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/user_stats.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_stats_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class UserStatsNotifier extends _$UserStatsNotifier {
+  @override
+  Future<UserStats> build() async {
+    final user = await ref.watch(authStateChangesProvider.future);
+    if (user == null || !user.emailVerified) {
+      return const UserStats(
+        todayViews: 0,
+        weekViews: 0,
+        totalViews: 0,
+        streakDays: 0,
+      );
+    }
+    final dataSource = ref.read(userStatsDataSourceProvider);
+    return dataSource.getStats(user.uid);
+  }
+
+  Future<void> refresh() async {
+    final user = ref.read(authStateChangesProvider).asData?.value;
+    if (user == null || !user.emailVerified) return;
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final dataSource = ref.read(userStatsDataSourceProvider);
+      return dataSource.refreshStats(user.uid);
+    });
+  }
+}

--- a/lib/features/user_archive/presentation/providers/user_stats_provider.g.dart
+++ b/lib/features/user_archive/presentation/providers/user_stats_provider.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_stats_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(UserStatsNotifier)
+final userStatsProvider = UserStatsNotifierProvider._();
+
+final class UserStatsNotifierProvider
+    extends $AsyncNotifierProvider<UserStatsNotifier, UserStats> {
+  UserStatsNotifierProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'userStatsProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$userStatsNotifierHash();
+
+  @$internal
+  @override
+  UserStatsNotifier create() => UserStatsNotifier();
+}
+
+String _$userStatsNotifierHash() => r'920e1d7c1eded90039cacaaf369d4bb12cbb9d2a';
+
+abstract class _$UserStatsNotifier extends $AsyncNotifier<UserStats> {
+  FutureOr<UserStats> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<UserStats>, UserStats>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<AsyncValue<UserStats>, UserStats>,
+        AsyncValue<UserStats>,
+        Object?,
+        Object?>;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -80,7 +80,7 @@ class _StreakCard extends StatelessWidget {
         child: Row(
           children: [
             Image.asset(
-              'assets/images/app_icon/icon.png',
+              'assets/images/app_icon.png',
               width: 28.w,
               height: 28.h,
             ),

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -79,7 +79,11 @@ class _StreakCard extends StatelessWidget {
         padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
         child: Row(
           children: [
-            Text('🔥', style: TextStyle(fontSize: 22.sp)),
+            Image.asset(
+              'assets/images/app_icon/icon.png',
+              width: 28.w,
+              height: 28.h,
+            ),
             SizedBox(width: 8.w),
             Expanded(
               child: Column(
@@ -159,13 +163,30 @@ class _AnimatedDaysCounterState extends State<_AnimatedDaysCounter>
     return AnimatedBuilder(
       animation: _animation,
       builder: (context, _) {
-        return Text(
-          '${_animation.value.toInt()}',
-          style: TextStyle(
-            fontSize: 32.sp,
-            fontWeight: FontWeight.bold,
-            color: colorScheme.primary,
-          ),
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '${_animation.value.toInt()}',
+              style: TextStyle(
+                fontSize: 32.sp,
+                fontWeight: FontWeight.bold,
+                color: colorScheme.primary,
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.only(bottom: 4.h),
+              child: Text(
+                '日',
+                style: TextStyle(
+                  fontSize: 13.sp,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.primary,
+                ),
+              ),
+            ),
+          ],
         );
       },
     );
@@ -241,13 +262,29 @@ class _CountCardState extends State<_CountCard>
                 : AnimatedBuilder(
                     animation: _animation,
                     builder: (context, _) {
-                      return Text(
-                        '${_animation.value.toInt()}',
-                        style: TextStyle(
-                          fontSize: 22.sp,
-                          fontWeight: FontWeight.bold,
-                          color: colorScheme.onSurface,
-                        ),
+                      return Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            '${_animation.value.toInt()}',
+                            style: TextStyle(
+                              fontSize: 22.sp,
+                              fontWeight: FontWeight.bold,
+                              color: colorScheme.onSurface,
+                            ),
+                          ),
+                          Padding(
+                            padding: EdgeInsets.only(bottom: 2.h),
+                            child: Text(
+                              '件',
+                              style: TextStyle(
+                                fontSize: 11.sp,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ),
+                        ],
                       );
                     },
                   ),
@@ -256,13 +293,6 @@ class _CountCardState extends State<_CountCard>
               widget.label,
               style: TextStyle(
                 fontSize: 11.sp,
-                color: colorScheme.onSurfaceVariant,
-              ),
-            ),
-            Text(
-              '件閲覧',
-              style: TextStyle(
-                fontSize: 10.sp,
                 color: colorScheme.onSurfaceVariant,
               ),
             ),

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:kenryo_tankyu/features/user_archive/domain/models/user_stats.dart';
+import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_stats_provider.dart';
+
+class UserStatsSection extends ConsumerWidget {
+  const UserStatsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncStats = ref.watch(userStatsProvider);
+
+    return asyncStats.when(
+      loading: () => _StatsLayout(stats: null),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (stats) => _StatsLayout(stats: stats),
+    );
+  }
+}
+
+class _StatsLayout extends StatelessWidget {
+  const _StatsLayout({required this.stats});
+
+  final UserStats? stats;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _StreakCard(streakDays: stats?.streakDays),
+        SizedBox(height: 8.h),
+        Row(
+          children: [
+            Expanded(
+              child: _CountCard(
+                label: '今日',
+                count: stats?.todayViews,
+                icon: Icons.today_outlined,
+              ),
+            ),
+            SizedBox(width: 8.w),
+            Expanded(
+              child: _CountCard(
+                label: '7日間',
+                count: stats?.weekViews,
+                icon: Icons.date_range_outlined,
+              ),
+            ),
+            SizedBox(width: 8.w),
+            Expanded(
+              child: _CountCard(
+                label: '累計',
+                count: stats?.totalViews,
+                icon: Icons.library_books_outlined,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _StreakCard extends StatelessWidget {
+  const _StreakCard({required this.streakDays});
+
+  final int? streakDays;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final days = streakDays ?? 0;
+
+    return Card(
+      color: colorScheme.primaryContainer,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
+        child: Row(
+          children: [
+            Text('🔥', style: TextStyle(fontSize: 22.sp)),
+            SizedBox(width: 8.w),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '$days日連続閲覧中！',
+                    style: TextStyle(
+                      fontSize: 15.sp,
+                      fontWeight: FontWeight.bold,
+                      color: colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                  Text(
+                    '毎日続けて探究を深めよう',
+                    style: TextStyle(
+                      fontSize: 11.sp,
+                      color:
+                          colorScheme.onPrimaryContainer.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            _AnimatedDaysCounter(days: days),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AnimatedDaysCounter extends StatefulWidget {
+  const _AnimatedDaysCounter({required this.days});
+  final int days;
+
+  @override
+  State<_AnimatedDaysCounter> createState() => _AnimatedDaysCounterState();
+}
+
+class _AnimatedDaysCounterState extends State<_AnimatedDaysCounter>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _animation = Tween<double>(begin: 0, end: widget.days.toDouble())
+        .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+    _controller.forward();
+  }
+
+  @override
+  void didUpdateWidget(_AnimatedDaysCounter old) {
+    super.didUpdateWidget(old);
+    if (old.days != widget.days) {
+      _animation = Tween<double>(begin: 0, end: widget.days.toDouble())
+          .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, _) {
+        return Text(
+          '${_animation.value.toInt()}',
+          style: TextStyle(
+            fontSize: 32.sp,
+            fontWeight: FontWeight.bold,
+            color: colorScheme.primary,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CountCard extends StatefulWidget {
+  const _CountCard({
+    required this.label,
+    required this.count,
+    required this.icon,
+  });
+
+  final String label;
+  final int? count;
+  final IconData icon;
+
+  @override
+  State<_CountCard> createState() => _CountCardState();
+}
+
+class _CountCardState extends State<_CountCard>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    );
+    _animation = Tween<double>(begin: 0, end: (widget.count ?? 0).toDouble())
+        .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+    if (widget.count != null) _controller.forward();
+  }
+
+  @override
+  void didUpdateWidget(_CountCard old) {
+    super.didUpdateWidget(old);
+    if (old.count != widget.count && widget.count != null) {
+      _animation = Tween<double>(begin: 0, end: widget.count!.toDouble())
+          .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isLoading = widget.count == null;
+
+    return Card(
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 12.h, horizontal: 8.w),
+        child: Column(
+          children: [
+            Icon(widget.icon, size: 20.sp, color: colorScheme.primary),
+            SizedBox(height: 4.h),
+            isLoading
+                ? SizedBox(
+                    height: 24.h,
+                    width: 24.w,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : AnimatedBuilder(
+                    animation: _animation,
+                    builder: (context, _) {
+                      return Text(
+                        '${_animation.value.toInt()}',
+                        style: TextStyle(
+                          fontSize: 22.sp,
+                          fontWeight: FontWeight.bold,
+                          color: colorScheme.onSurface,
+                        ),
+                      );
+                    },
+                  ),
+            SizedBox(height: 2.h),
+            Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 11.sp,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            Text(
+              '件閲覧',
+              style: TextStyle(
+                fontSize: 10.sp,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -15,6 +15,8 @@ class UserStatsSection extends ConsumerWidget {
       loading: () => _StatsLayout(stats: null),
       error: (_, __) => const SizedBox.shrink(),
       data: (stats) => _StatsLayout(stats: stats),
+      // リフレッシュ中は前回データを表示し続ける（チラつき防止）
+      skipLoadingOnReload: true,
     );
   }
 }
@@ -71,6 +73,7 @@ class _StreakCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final isLoading = streakDays == null;
     final days = streakDays ?? 0;
 
     return Card(
@@ -90,7 +93,7 @@ class _StreakCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    '$days日連続閲覧中！',
+                    isLoading ? '読み込み中...' : '$days日連続閲覧中！',
                     style: TextStyle(
                       fontSize: 15.sp,
                       fontWeight: FontWeight.bold,
@@ -108,7 +111,7 @@ class _StreakCard extends StatelessWidget {
                 ],
               ),
             ),
-            _AnimatedDaysCounter(days: days),
+            if (!isLoading) _AnimatedDaysCounter(days: days),
           ],
         ),
       ),
@@ -145,8 +148,11 @@ class _AnimatedDaysCounterState extends State<_AnimatedDaysCounter>
   void didUpdateWidget(_AnimatedDaysCounter old) {
     super.didUpdateWidget(old);
     if (old.days != widget.days) {
-      _animation = Tween<double>(begin: 0, end: widget.days.toDouble())
-          .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+      // 前回の値から始めることで自然なカウントアップになる
+      _animation = Tween<double>(
+        begin: old.days.toDouble(),
+        end: widget.days.toDouble(),
+      ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
       _controller.forward(from: 0);
     }
   }
@@ -229,7 +235,9 @@ class _CountCardState extends State<_CountCard>
   void didUpdateWidget(_CountCard old) {
     super.didUpdateWidget(old);
     if (old.count != widget.count && widget.count != null) {
-      _animation = Tween<double>(begin: 0, end: widget.count!.toDouble())
+      // 前回の値から始めることで自然なカウントアップになる
+      final begin = (old.count ?? 0).toDouble();
+      _animation = Tween<double>(begin: begin, end: widget.count!.toDouble())
           .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
       _controller.forward(from: 0);
     }
@@ -257,7 +265,7 @@ class _CountCardState extends State<_CountCard>
                 ? SizedBox(
                     height: 24.h,
                     width: 24.w,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: const CircularProgressIndicator(strokeWidth: 2),
                   )
                 : AnimatedBuilder(
                     animation: _animation,

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -5,6 +5,7 @@ import "package:kenryo_tankyu/core/constants/app_unique_value.dart";
 import 'package:kenryo_tankyu/features/search/presentation/widgets/result_preview_content.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
+import 'package:kenryo_tankyu/features/user_archive/presentation/widgets/user_stats_section.dart';
 import 'package:kenryo_tankyu/presentation/widget/error_view.dart';
 import 'package:kenryo_tankyu/presentation/widget/startup_dialogs.dart';
 
@@ -49,6 +50,8 @@ class _HomePageState extends ConsumerState<HomePage> {
               ],
             ),
             const SizedBox(height: 8),
+            const UserStatsSection(),
+            const SizedBox(height: 16),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [


### PR DESCRIPTION
## 概要
ホーム画面に閲覧統計カード（今日/7日間/累計）と連続閲覧ストリークを追加し、UI/UXを向上させる。

## 種別
- [x] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #125

## 変更内容
- `UserStats` ドメインモデル（freezed）を追加
- `UserStatsDataSource` を新規作成
  - Supabase の `browsing_history` テーブルに対して COUNT クエリを3件並列実行（今日/7日間/累計）
  - SharedPreferences に1時間キャッシュし、通信量を最小化
- 連続閲覧ストリークをローカル（SharedPreferences）で管理
  - アプリ起動時に前回起動日と比較し、連続 or リセットを判定
  - Supabase の upsert 制約（PRIMARY KEY: user_id + document_id）による計算ズレを回避
- `UserStatsNotifier`（Riverpod）を追加
- `UserStatsSection` ウィジェットを新規作成
  - ストリークカード：アプリアイコン + 連続日数（カウントアップアニメーション）
  - 件数カード3枚横並び：今日・7日間・累計（カウントアップアニメーション）
  - 数字横に小さく「日」「件」を表示

## スクリーンショット
（動作確認後に追加）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）