### PR TITLE
[LibraryPage] タブUIをMaterial標準に刷新

### DIFF
--- a/lib/presentation/screens/library_page.dart
+++ b/lib/presentation/screens/library_page.dart
@@ -1,80 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/widgets/history_list.dart';
 
-///TODO あまり納得いってないよこのタブ
-///あと、riverpod使わずにstateful使っちゃってるのちょっと罪悪感あるし！
-///ゆーてstateprovider１つ使うだけでよさそうなんだよな。
-
-class LibraryPage extends StatefulWidget {
+class LibraryPage extends StatelessWidget {
   const LibraryPage({super.key});
 
   @override
-  State<LibraryPage> createState() => _LibraryPageState();
-}
-
-class _LibraryPageState extends State<LibraryPage>
-    with SingleTickerProviderStateMixin {
-  late TabController _tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: 2, vsync: this);
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-    _tabController.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        flexibleSpace: Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Container(
-            decoration: BoxDecoration(
-                color: Colors.grey.shade300,
-                borderRadius: BorderRadius.circular(25.0)),
-            child: TabBar(
-              indicatorWeight: 3.0,
-              controller: _tabController,
-              indicator: BoxDecoration(
-                borderRadius: BorderRadius.circular(25.0),
-                color: Theme.of(context).primaryColor,
-              ),
-              labelColor: Colors.white,
-              tabs: [
-                _tab(label: '閲覧履歴', icon: const Icon(Icons.history)),
-                _tab(label: 'お気に入り', icon: const Icon(Icons.favorite)),
-              ],
-            ),
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          bottom: const TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.history), text: '閲覧履歴'),
+              Tab(icon: Icon(Icons.favorite), text: 'お気に入り'),
+            ],
           ),
         ),
-      ),
-      body: TabBarView(
-        controller: _tabController,
-        children: const <Widget>[
-          LibraryList(onlyFavorite: false),
-          LibraryList(onlyFavorite: true),
-        ], //TODO,, tabcontrollerがindexを管理してくれているから、順番に作っちゃうだけでおけ
-      ),
-    );
-  }
-
-  Widget _tab({required String label, required Icon icon}) {
-    return Tab(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          icon,
-          const SizedBox(width: 8.0),
-          Text(label),
-        ],
+        body: const TabBarView(
+          children: [
+            LibraryList(onlyFavorite: false),
+            LibraryList(onlyFavorite: true),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/screens/library_page.dart
+++ b/lib/presentation/screens/library_page.dart
@@ -11,10 +11,29 @@ class LibraryPage extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           automaticallyImplyLeading: false,
+          toolbarHeight: 0,
           bottom: const TabBar(
             tabs: [
-              Tab(icon: Icon(Icons.history), text: '閲覧履歴'),
-              Tab(icon: Icon(Icons.favorite), text: 'お気に入り'),
+              Tab(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.history),
+                    SizedBox(width: 6),
+                    Text('閲覧履歴'),
+                  ],
+                ),
+              ),
+              Tab(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.favorite),
+                    SizedBox(width: 6),
+                    Text('お気に入り'),
+                  ],
+                ),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## 概要
LibraryPage（閲覧履歴・お気に入り）のタブUIをカスタム実装からMaterial 3標準のTabBarに刷新する。

## 種別
- [ ] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明）

## 関連Issue
なし

## 変更内容
- カスタムの灰色角丸コンテナ＋塗りつぶしインジケーターを廃止し、Material 3標準の`TabBar`スタイルに変更
- `StatefulWidget` + 手動`TabController` → `DefaultTabController` + `StatelessWidget` に簡略化
- `AppBar(flexibleSpace:)`の無理やり配置 → `AppBar(bottom: TabBar(...))`の正規の使い方に変更
- `toolbarHeight: 0`でAppBarツールバー部分の余分な空白を除去
- タブを`Tab(icon, text)`の縦並びから`Row`で横並び（アイコン＋テキスト）に変更し高さを最小化
- 68行 → 51行

## スクリーンショット
（実機確認済み）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）