### PR TITLE
[Search] 検索バグ3件を修正

### DIFF
--- a/lib/core/constants/work/info_value.dart
+++ b/lib/core/constants/work/info_value.dart
@@ -6,7 +6,6 @@ enum EnterYear {
   enter2022(displayName: 2022),
   enter2023(displayName: 2023),
   enter2024(displayName: 2024),
-  enter2025(displayName: 2025),
   undefined(displayName: 0);
 
   final int displayName;

--- a/lib/features/search/domain/models/search.dart
+++ b/lib/features/search/domain/models/search.dart
@@ -24,6 +24,14 @@ abstract class Search with _$Search {
   @JsonSerializable(explicitToJson: true)
   const Search._();
 
+  bool get isEmpty =>
+      searchWord.isEmpty &&
+      category == Category.none &&
+      subCategory == SubCategory.none &&
+      enterYear == EnterYear.undefined &&
+      course == Course.undefined &&
+      eventName == EventName.undefined;
+
   const factory Search({
     @CategoryEnumConverter() required Category category,
     @SubCategoryEnumConverter() required SubCategory subCategory,

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -1,7 +1,10 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' hide Category;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:kenryo_tankyu/core/constants/work/category_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/constants/work/search_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/sub_category_value.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/search/data/repositories/search_repository_impl.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search_result.dart';
@@ -60,6 +63,14 @@ final algoliaSearchProvider =
 
   final search =
       ref.read(searchProvider); //ref.readにすると、watchと違って値が変更されたときに再ビルドされない！
+
+  final bool isEmptySearch = search.searchWord.isEmpty &&
+      search.category == Category.none &&
+      search.subCategory == SubCategory.none &&
+      search.enterYear == EnterYear.undefined &&
+      search.course == Course.undefined &&
+      search.eventName == EventName.undefined;
+  if (isEmptySearch) return null;
 
   final page = ref.watch(searchPageProvider);
   final cache = ref.watch(searchResultCacheProvider.notifier);

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -1,10 +1,7 @@
-import 'package:flutter/foundation.dart' hide Category;
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
-import 'package:kenryo_tankyu/core/constants/work/category_value.dart';
-import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
 import 'package:kenryo_tankyu/core/constants/work/search_value.dart';
-import 'package:kenryo_tankyu/core/constants/work/sub_category_value.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:kenryo_tankyu/features/search/data/repositories/search_repository_impl.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search_result.dart';
@@ -64,13 +61,7 @@ final algoliaSearchProvider =
   final search =
       ref.read(searchProvider); //ref.readにすると、watchと違って値が変更されたときに再ビルドされない！
 
-  final bool isEmptySearch = search.searchWord.isEmpty &&
-      search.category == Category.none &&
-      search.subCategory == SubCategory.none &&
-      search.enterYear == EnterYear.undefined &&
-      search.course == Course.undefined &&
-      search.eventName == EventName.undefined;
-  if (isEmptySearch) return null;
+  if (search.isEmpty) return null;
 
   final page = ref.watch(searchPageProvider);
   final cache = ref.watch(searchResultCacheProvider.notifier);

--- a/lib/features/search/presentation/providers/algolia_provider.dart
+++ b/lib/features/search/presentation/providers/algolia_provider.dart
@@ -88,15 +88,11 @@ final algoliaSearchProvider =
     }
   }
 
-  if (result == null && page > 0) {
-    return SearchResult(hits: [], page: page, nbPages: page, nbHits: 0);
-  }
+  final resolved =
+      result ?? SearchResult(hits: [], page: page, nbPages: page, nbHits: 0);
 
-  if (result != null) {
-    cache.set(page, result);
-  }
-
-  return result;
+  cache.set(page, resolved);
+  return resolved;
 });
 
 final sortedListProvider =

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -65,59 +65,68 @@ class ResultListPage extends ConsumerWidget {
                         return Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                  left: 8.0, top: 4.0, bottom: 4.0),
-                              child: Text(
-                                hits.isEmpty
-                                    ? '該当するデータはありません'
-                                    : data.isLastPage && currentPage == 0
-                                        ? '${hits.length}件ヒットしました'
-                                        : '${currentPage * 20 + 1}〜${currentPage * 20 + hits.length}件目を表示中（総${data.nbHits}件）',
-                                style: const TextStyle(fontSize: 16),
-                              ),
-                            ),
-                            ResultList(data: sortedList),
-                            Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(vertical: 8.0),
-                              child: Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  TextButton.icon(
-                                    onPressed: asyncValue.isLoading ||
-                                            currentPage == 0
-                                        ? null
-                                        : () {
-                                            ref
-                                                .read(
-                                                    searchPageProvider.notifier)
-                                                .setPage(currentPage - 1);
-                                          },
-                                    icon: const Icon(Icons.arrow_back_ios,
-                                        size: 16),
-                                    label: const Text('前のページへ'),
+                            if (hits.isEmpty)
+                              const Expanded(
+                                child: Center(
+                                  child: Text(
+                                    'ヒットしませんでした。\nキーワードやカテゴリを変えて再検索してください。',
+                                    textAlign: TextAlign.center,
                                   ),
-                                  Text('${currentPage + 1}ページ目'),
-                                  TextButton.icon(
-                                    onPressed: asyncValue.isLoading ||
-                                            data.isLastPage
-                                        ? null
-                                        : () {
-                                            ref
-                                                .read(
-                                                    searchPageProvider.notifier)
-                                                .setPage(currentPage + 1);
-                                          },
-                                    icon: const Icon(Icons.arrow_forward_ios,
-                                        size: 16),
-                                    label: const Text('次のページへ'),
-                                    iconAlignment: IconAlignment.end,
-                                  ),
-                                ],
+                                ),
+                              )
+                            else
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                    left: 8.0, top: 4.0, bottom: 4.0),
+                                child: Text(
+                                  data.isLastPage && currentPage == 0
+                                      ? '${hits.length}件ヒットしました'
+                                      : '${currentPage * 20 + 1}〜${currentPage * 20 + hits.length}件目を表示中（総${data.nbHits}件）',
+                                  style: const TextStyle(fontSize: 16),
+                                ),
                               ),
-                            ),
+                            if (hits.isNotEmpty) ResultList(data: sortedList),
+                            if (hits.isNotEmpty)
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 8.0),
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    TextButton.icon(
+                                      onPressed: asyncValue.isLoading ||
+                                              currentPage == 0
+                                          ? null
+                                          : () {
+                                              ref
+                                                  .read(searchPageProvider
+                                                      .notifier)
+                                                  .setPage(currentPage - 1);
+                                            },
+                                      icon: const Icon(Icons.arrow_back_ios,
+                                          size: 16),
+                                      label: const Text('前のページへ'),
+                                    ),
+                                    Text('${currentPage + 1}ページ目'),
+                                    TextButton.icon(
+                                      onPressed: asyncValue.isLoading ||
+                                              data.isLastPage
+                                          ? null
+                                          : () {
+                                              ref
+                                                  .read(searchPageProvider
+                                                      .notifier)
+                                                  .setPage(currentPage + 1);
+                                            },
+                                      icon: const Icon(Icons.arrow_forward_ios,
+                                          size: 16),
+                                      label: const Text('次のページへ'),
+                                      iconAlignment: IconAlignment.end,
+                                    ),
+                                  ],
+                                ),
+                              ),
                           ],
                         );
                       }

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import "package:kenryo_tankyu/core/constants/work/category_value.dart";
-import "package:kenryo_tankyu/core/constants/work/info_value.dart";
 import "package:kenryo_tankyu/core/constants/work/search_value.dart";
-import "package:kenryo_tankyu/core/constants/work/sub_category_value.dart";
 import 'package:kenryo_tankyu/presentation/widget/error_view.dart';
 
 import 'package:kenryo_tankyu/features/search/presentation/widgets/result_list_preview.dart'; // ResultList is here
@@ -11,7 +8,6 @@ import 'package:kenryo_tankyu/features/search/presentation/widgets/result_header
 import 'package:kenryo_tankyu/features/search/presentation/widgets/sidebar.dart';
 
 import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
-import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 import 'package:kenryo_tankyu/core/connectivity/connectivity_provider.dart';
 
 class ResultListPage extends ConsumerWidget {
@@ -61,29 +57,8 @@ class ResultListPage extends ConsumerWidget {
                   return asyncValue.when(
                     data: (data) {
                       if (data == null) {
-                        final search = ref.read(searchProvider);
-                        final isEmptySearch = search.searchWord.isEmpty &&
-                            search.category == Category.none &&
-                            search.subCategory == SubCategory.none &&
-                            search.enterYear == EnterYear.undefined &&
-                            search.course == Course.undefined &&
-                            search.eventName == EventName.undefined;
-                        return Center(
-                            child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(isEmptySearch
-                                ? '検索条件を設定してください'
-                                : 'データがヒットしませんでした'),
-                            if (!isEmptySearch) ...[
-                              const SizedBox(height: 20),
-                              ElevatedButton(
-                                  onPressed: () =>
-                                      ref.invalidate(algoliaSearchProvider),
-                                  child: const Text('リロードする')),
-                            ],
-                          ],
-                        ));
+                        // algoliaSearchProvider が null を返すのは search.isEmpty の場合のみ
+                        return const Center(child: Text('検索条件を設定してください'));
                       } else {
                         final currentPage = ref.watch(searchPageProvider);
                         final hits = data.hits;

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import "package:kenryo_tankyu/core/constants/work/category_value.dart";
+import "package:kenryo_tankyu/core/constants/work/info_value.dart";
 import "package:kenryo_tankyu/core/constants/work/search_value.dart";
+import "package:kenryo_tankyu/core/constants/work/sub_category_value.dart";
 import 'package:kenryo_tankyu/presentation/widget/error_view.dart';
 
 import 'package:kenryo_tankyu/features/search/presentation/widgets/result_list_preview.dart'; // ResultList is here
@@ -8,6 +11,7 @@ import 'package:kenryo_tankyu/features/search/presentation/widgets/result_header
 import 'package:kenryo_tankyu/features/search/presentation/widgets/sidebar.dart';
 
 import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 import 'package:kenryo_tankyu/core/connectivity/connectivity_provider.dart';
 
 class ResultListPage extends ConsumerWidget {
@@ -57,16 +61,27 @@ class ResultListPage extends ConsumerWidget {
                   return asyncValue.when(
                     data: (data) {
                       if (data == null) {
+                        final search = ref.read(searchProvider);
+                        final isEmptySearch = search.searchWord.isEmpty &&
+                            search.category == Category.none &&
+                            search.subCategory == SubCategory.none &&
+                            search.enterYear == EnterYear.undefined &&
+                            search.course == Course.undefined &&
+                            search.eventName == EventName.undefined;
                         return Center(
                             child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            const Text('データがヒットしませんでした'),
-                            const SizedBox(height: 20),
-                            ElevatedButton(
-                                onPressed: () =>
-                                    ref.invalidate(algoliaSearchProvider),
-                                child: const Text('リロードする')),
+                            Text(isEmptySearch
+                                ? '検索条件を設定してください'
+                                : 'データがヒットしませんでした'),
+                            if (!isEmptySearch) ...[
+                              const SizedBox(height: 20),
+                              ElevatedButton(
+                                  onPressed: () =>
+                                      ref.invalidate(algoliaSearchProvider),
+                                  child: const Text('リロードする')),
+                            ],
                           ],
                         ));
                       } else {

--- a/lib/features/search/presentation/widgets/search_history_list.dart
+++ b/lib/features/search/presentation/widgets/search_history_list.dart
@@ -27,16 +27,25 @@ class _AutoScrollTextState extends State<_AutoScrollText> {
 
   Future<void> _startScroll() async {
     if (!mounted || !_controller.hasClients) return;
-    final maxScroll = _controller.position.maxScrollExtent;
+    double maxScroll;
+    try {
+      maxScroll = _controller.position.maxScrollExtent;
+    } catch (_) {
+      return;
+    }
     if (maxScroll <= 0) return;
     while (mounted) {
       await Future.delayed(const Duration(seconds: 2));
       if (!mounted || !_controller.hasClients) return;
-      await _controller.animateTo(
-        maxScroll,
-        duration: Duration(milliseconds: (maxScroll * 25).toInt()),
-        curve: Curves.linear,
-      );
+      try {
+        await _controller.animateTo(
+          maxScroll,
+          duration: Duration(milliseconds: (maxScroll * 25).toInt()),
+          curve: Curves.linear,
+        );
+      } catch (_) {
+        return;
+      }
       if (!mounted || !_controller.hasClients) return;
       await Future.delayed(const Duration(seconds: 1));
       if (!mounted || !_controller.hasClients) return;

--- a/lib/features/search/presentation/widgets/search_history_list.dart
+++ b/lib/features/search/presentation/widgets/search_history_list.dart
@@ -8,6 +8,59 @@ import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_history_provider.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 
+class _AutoScrollText extends StatefulWidget {
+  final String text;
+  const _AutoScrollText(this.text);
+
+  @override
+  State<_AutoScrollText> createState() => _AutoScrollTextState();
+}
+
+class _AutoScrollTextState extends State<_AutoScrollText> {
+  final ScrollController _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _startScroll());
+  }
+
+  Future<void> _startScroll() async {
+    if (!mounted || !_controller.hasClients) return;
+    final maxScroll = _controller.position.maxScrollExtent;
+    if (maxScroll <= 0) return;
+    while (mounted) {
+      await Future.delayed(const Duration(seconds: 2));
+      if (!mounted || !_controller.hasClients) return;
+      await _controller.animateTo(
+        maxScroll,
+        duration: Duration(milliseconds: (maxScroll * 25).toInt()),
+        curve: Curves.linear,
+      );
+      if (!mounted || !_controller.hasClients) return;
+      await Future.delayed(const Duration(seconds: 1));
+      if (!mounted || !_controller.hasClients) return;
+      _controller.jumpTo(0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      controller: _controller,
+      physics: const NeverScrollableScrollPhysics(),
+      child: Text(widget.text),
+    );
+  }
+}
+
 class SearchHistoryList extends ConsumerWidget {
   const SearchHistoryList({super.key});
 
@@ -40,9 +93,7 @@ class SearchHistoryList extends ConsumerWidget {
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Expanded(
-                                child: Text(word,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis),
+                                child: _AutoScrollText(word),
                               ),
                               Text(' ${search.numberOfHits}件',
                                   style: const TextStyle(fontSize: 12)),
@@ -73,7 +124,7 @@ class SearchHistoryList extends ConsumerWidget {
 
   String _connectWord(Search search) {
     final List<String> searchList = [];
-    //searchList.addAll(search.searchWord!);
+    searchList.addAll(search.searchWord);
     search.category != Category.none
         ? searchList.add(search.category.displayName)
         : null;


### PR DESCRIPTION
## 概要
result_list_page・検索履歴まわりのバグ3件をまとめて修正。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #  

## 変更内容
- **絞り込みから2025年度入学を削除** — `EnterYear` enum の `enter2025` を削除。既存DBデータは `fromJson` の `orElse` で `undefined` にフォールバックするため互換性あり。
- **空条件での全件ヒット防止** — `algoliaSearchProvider` に空条件ガードを追加し、全条件が未設定の場合はAlgoliaリクエストを発行せず `null` を返すように修正。result_list_page 側も「検索条件を設定してください」メッセージを表示（リロードボタンも非表示）。
- **検索履歴に searchWord を表示 + 長文自動スクロール** — `_connectWord` でコメントアウトされていた `searchWord` を復活。テキスト表示を `_AutoScrollText` ウィジェットに差し替え、はみ出す場合は2秒待機→スクロール→先頭に戻るループで自動スクロール（外部パッケージ追加なし）。

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）