### PR TITLE
[Auth] アカウント削除時の requires-recent-login エラーを再認証フローで解消

### DIFF
--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -109,6 +109,10 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   @override
   Future<bool> reauthenticateWithGoogle() async {
     try {
+      // キャッシュされた認証情報を使わず、必ず再認証UIを表示させるためにサインアウトする
+      try {
+        await GoogleSignIn.instance.signOut();
+      } catch (_) {}
       final account = await GoogleSignIn.instance.authenticate();
       final idToken = account.authentication.idToken;
       final credential = GoogleAuthProvider.credential(idToken: idToken);

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -22,6 +22,12 @@ abstract class AuthRemoteDataSource {
 
   /// Googleサインインを試みる。ユーザーがキャンセルした場合は false を返す。
   Future<bool> signInWithGoogle();
+
+  Future<void> reauthenticateWithEmailAndPassword(
+      {required String email, required String password});
+
+  /// Googleで再認証を試みる。ユーザーがキャンセルした場合は false を返す。
+  Future<bool> reauthenticateWithGoogle();
 }
 
 class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
@@ -88,6 +94,37 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
     final user = _firebaseAuth.currentUser;
     if (user == null) throw StateError('User not logged in');
     await user.reload();
+  }
+
+  @override
+  Future<void> reauthenticateWithEmailAndPassword(
+      {required String email, required String password}) async {
+    final user = _firebaseAuth.currentUser;
+    if (user == null) throw StateError('User not logged in');
+    final credential =
+        EmailAuthProvider.credential(email: email, password: password);
+    await user.reauthenticateWithCredential(credential);
+  }
+
+  @override
+  Future<bool> reauthenticateWithGoogle() async {
+    try {
+      final account = await GoogleSignIn.instance.authenticate();
+      final idToken = account.authentication.idToken;
+      final credential = GoogleAuthProvider.credential(idToken: idToken);
+      final user = _firebaseAuth.currentUser;
+      if (user == null) throw StateError('User not logged in');
+      await user.reauthenticateWithCredential(credential);
+      return true;
+    } on GoogleSignInException catch (e) {
+      switch (e.code) {
+        case GoogleSignInExceptionCode.canceled:
+        case GoogleSignInExceptionCode.interrupted:
+          return false;
+        default:
+          rethrow;
+      }
+    }
   }
 
   @override

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -116,6 +116,31 @@ class AuthRepositoryImpl with ErrorMapper implements AuthRepository {
     }
   }
 
+  @override
+  Future<void> reauthenticateWithEmailAndPassword(
+      {required String email, required String password}) async {
+    try {
+      await _dataSource
+          .reauthenticateWithEmailAndPassword(email: email, password: password)
+          .timeout(const Duration(seconds: 10));
+    } on FirebaseAuthException catch (e) {
+      throw _mapFirebaseException(e);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
+  @override
+  Future<bool> reauthenticateWithGoogle() async {
+    try {
+      return await _dataSource.reauthenticateWithGoogle();
+    } on FirebaseAuthException catch (e) {
+      throw _mapFirebaseException(e);
+    } catch (e) {
+      throw mapException(e);
+    }
+  }
+
   Failure _mapFirebaseException(FirebaseAuthException e) {
     if (e.code == 'unavailable' || e.code == 'network-request-failed') {
       return const NetworkFailure();

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -14,4 +14,7 @@ abstract class AuthRepository {
   Future<void> sendEmailVerification();
   Future<void> reloadUser();
   Future<bool> signInWithGoogle();
+  Future<void> reauthenticateWithEmailAndPassword(
+      {required String email, required String password});
+  Future<bool> reauthenticateWithGoogle();
 }

--- a/lib/features/settings/presentation/screens/settings_page.dart
+++ b/lib/features/settings/presentation/screens/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:kenryo_tankyu/features/settings/presentation/widgets/delete_data
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:kenryo_tankyu/presentation/widget/error_dialog.dart';
 import 'package:kenryo_tankyu/core/error/failures.dart';
+import 'package:kenryo_tankyu/features/auth/domain/models/auth_failure.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -216,23 +217,8 @@ class SettingsPage extends ConsumerWidget {
                         ),
                         TextButton(
                           onPressed: () async {
-                            try {
-                              await ref
-                                  .read(authProvider.notifier)
-                                  .deleteAccount();
-                              if (!context.mounted) return;
-                              Navigator.of(context).pop();
-                            } on Failure catch (e) {
-                              if (!context.mounted) return;
-                              Navigator.of(context).pop();
-                              showErrorDialog(context, e);
-                            } catch (e) {
-                              if (!context.mounted) return;
-                              Navigator.of(context).pop();
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text('予期せぬエラーが発生しました: $e')),
-                              );
-                            }
+                            Navigator.of(context).pop();
+                            await _deleteAccountWithReauth(context, ref);
                           },
                           child: const Text('はい'),
                         ),
@@ -246,6 +232,111 @@ class SettingsPage extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _deleteAccountWithReauth(
+      BuildContext context, WidgetRef ref) async {
+    try {
+      await ref.read(authProvider.notifier).deleteAccount();
+    } on RequiresRecentLogin {
+      if (!context.mounted) return;
+      final user = ref.read(authRepositoryProvider).currentUser;
+      final isGoogle =
+          user?.providerData.any((p) => p.providerId == 'google.com') ?? false;
+      if (isGoogle) {
+        await _reauthWithGoogleAndDelete(context, ref);
+      } else {
+        await _reauthWithPasswordAndDelete(context, ref);
+      }
+    } on Failure catch (e) {
+      if (!context.mounted) return;
+      showErrorDialog(context, e);
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('予期せぬエラーが発生しました: $e')),
+      );
+    }
+  }
+
+  Future<void> _reauthWithGoogleAndDelete(
+      BuildContext context, WidgetRef ref) async {
+    try {
+      final reauthenticated =
+          await ref.read(authRepositoryProvider).reauthenticateWithGoogle();
+      if (!reauthenticated) return;
+      if (!context.mounted) return;
+      await ref.read(authProvider.notifier).deleteAccount();
+    } on Failure catch (e) {
+      if (!context.mounted) return;
+      showErrorDialog(context, e);
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('予期せぬエラーが発生しました: $e')),
+      );
+    }
+  }
+
+  Future<void> _reauthWithPasswordAndDelete(
+      BuildContext context, WidgetRef ref) async {
+    final passwordController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('再認証が必要です'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('セキュリティのため、パスワードを入力してアカウント削除を続けてください。'),
+            const SizedBox(height: 16),
+            TextField(
+              controller: passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(
+                labelText: 'パスワード',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('削除する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) {
+      passwordController.dispose();
+      return;
+    }
+    final password = passwordController.text;
+    passwordController.dispose();
+
+    if (!context.mounted) return;
+    try {
+      final user = ref.read(authRepositoryProvider).currentUser;
+      final email = user?.email ?? '';
+      await ref
+          .read(authRepositoryProvider)
+          .reauthenticateWithEmailAndPassword(email: email, password: password);
+      await ref.read(authProvider.notifier).deleteAccount();
+    } on Failure catch (e) {
+      if (!context.mounted) return;
+      showErrorDialog(context, e);
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('予期せぬエラーが発生しました: $e')),
+      );
+    }
   }
 
   Future<void> _showDeleteDataDialog(

--- a/lib/features/settings/presentation/screens/settings_page.dart
+++ b/lib/features/settings/presentation/screens/settings_page.dart
@@ -264,8 +264,13 @@ class SettingsPage extends ConsumerWidget {
     try {
       final reauthenticated =
           await ref.read(authRepositoryProvider).reauthenticateWithGoogle();
-      if (!reauthenticated) return;
       if (!context.mounted) return;
+      if (!reauthenticated) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Googleサインインがキャンセルされました')),
+        );
+        return;
+      }
       await ref.read(authProvider.notifier).deleteAccount();
     } on Failure catch (e) {
       if (!context.mounted) return;


### PR DESCRIPTION
## 概要
ログインから時間が経ってアカウント削除を試みると「サーバーエラー」（`requires-recent-login`）が表示されバグを修正。再認証フローを追加し、削除を継続できるようにした。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #  

## 変更内容
- `AuthRemoteDataSource` / `AuthRepository` に `reauthenticateWithEmailAndPassword` と `reauthenticateWithGoogle` を追加
- アカウント削除時に `RequiresRecentLogin` が発生した場合、サインイン方法に応じて再認証フローに分岐
  - **Googleログインユーザー**: `GoogleSignIn.instance.signOut()` でキャッシュをクリアしてアカウントピッカーを表示 → 再認証 → 削除を再試行
  - **メール/パスワードユーザー**: パスワード入力ダイアログを表示 → 再認証 → 削除を再試行
- 再認証がキャンセルされた場合にスナックバーでユーザーへ通知

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）