### PR TITLE
[WorkInfoSection] アイコン表示・タイトルタップ・クラス名を修正

### DIFF
--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -96,7 +96,7 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
             body: Padding(
               padding: const EdgeInsets.only(top: 4.0, left: 8.0, right: 8.0),
               child: Column(children: [
-                WorkTitle(
+                WorkInfoSection(
                   searched: searchedData,
                   isDetailsExpanded: _isDetailsExpanded,
                   onToggleDetails: () =>

--- a/lib/features/research_work/presentation/widgets/work_info_section.dart
+++ b/lib/features/research_work/presentation/widgets/work_info_section.dart
@@ -117,27 +117,12 @@ class _CategoryChip extends StatelessWidget {
 
   String? _imagePath(bool isDark) {
     const imageDir = 'assets/images/categories/';
-    const validNames = {
-      'history',
-      'rights',
-      'international',
-      'business',
-      'education',
-      'industry',
-      'environment',
-      'science',
-      'technology',
-      'health',
-      'art',
-      'life',
-      'society',
-    };
     if (category == Category.other) {
       return isDark
           ? '${imageDir}other_for_dark.png'
           : '${imageDir}other_for_light.png';
     }
-    if (validNames.contains(category.name)) {
+    if (category != Category.none) {
       return '$imageDir${category.name}.png';
     }
     return null;

--- a/lib/features/research_work/presentation/widgets/work_info_section.dart
+++ b/lib/features/research_work/presentation/widgets/work_info_section.dart
@@ -5,12 +5,12 @@ import "package:kenryo_tankyu/core/constants/work/info_value.dart";
 import "package:kenryo_tankyu/core/constants/work/sub_category_value.dart";
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 
-class WorkTitle extends StatelessWidget {
+class WorkInfoSection extends StatelessWidget {
   final Searched searched;
   final bool isDetailsExpanded;
   final VoidCallback onToggleDetails;
 
-  const WorkTitle({
+  const WorkInfoSection({
     super.key,
     required this.searched,
     required this.isDetailsExpanded,
@@ -19,21 +19,23 @@ class WorkTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: Text(
-              searched.title,
-              softWrap: true,
-              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+    return GestureDetector(
+      onTap: onToggleDetails,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Text(
+                searched.title,
+                softWrap: true,
+                style:
+                    const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
             ),
-          ),
-          GestureDetector(
-            onTap: onToggleDetails,
-            child: Padding(
+            Padding(
               padding: const EdgeInsets.only(left: 8.0, top: 4.0),
               child: Icon(
                 isDetailsExpanded
@@ -46,8 +48,8 @@ class WorkTitle extends StatelessWidget {
                     .withValues(alpha: 0.5),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -121,6 +123,8 @@ class _CategoryChip extends StatelessWidget {
       'international',
       'business',
       'education',
+      'industry',
+      'environment',
       'science',
       'technology',
       'health',


### PR DESCRIPTION
## 概要
`work_info_section.dart` の3つの問題をまとめて修正。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #  

## 変更内容
- **industry.png が表示されない**: `_CategoryChip._imagePath` の `validNames` セットに `industry` と `environment` が含まれていなかったため、該当カテゴリのアイコンが常に非表示になっていた。両カテゴリを追加して修正。
- **タイトルタップで詳細開閉**: 三角アイコンのみに付いていた `GestureDetector` をタイトル行全体へ拡張し、タイトルテキストをタップしても詳細が開閉できるよう変更（`HitTestBehavior.opaque` で余白部分も反応）。
- **クラス名の統一**: ファイル名 `work_info_section.dart` と一致させるため `WorkTitle` → `WorkInfoSection` にリネーム。`result_page.dart` の参照も追従。

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）