### PR TITLE
[Security] Supabase RLS有効化・Firebase Third-party Auth連携・iOSアプリ名修正

### DIFF
--- a/document/supabase_rls_policies.sql
+++ b/document/supabase_rls_policies.sql
@@ -1,7 +1,10 @@
 -- =============================================================
 -- Supabase RLS (Row Level Security) ポリシー設定
--- 前提: Supabase Dashboard > Authentication > Third-party Auth
---       で Firebase プロジェクトを登録済みであること
+-- 前提: Supabase Dashboard > Authentication > Sign In / Providers
+--       > Third-Party Auth で Firebase プロジェクトを登録済みであること
+--
+-- Firebase UID は UUID 形式ではないため auth.uid() は使用不可。
+-- auth.jwt() ->> 'sub' でJWTのsubクレームをテキストとして取得する。
 -- =============================================================
 
 -- browsing_history
@@ -10,8 +13,8 @@ ALTER TABLE browsing_history ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "browsing_history: 本人のみ全操作可"
   ON browsing_history
   FOR ALL
-  USING (auth.uid()::text = user_id)
-  WITH CHECK (auth.uid()::text = user_id);
+  USING ((auth.jwt() ->> 'sub') = user_id)
+  WITH CHECK ((auth.jwt() ->> 'sub') = user_id);
 
 -- favorites
 ALTER TABLE favorites ENABLE ROW LEVEL SECURITY;
@@ -19,8 +22,8 @@ ALTER TABLE favorites ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "favorites: 本人のみ全操作可"
   ON favorites
   FOR ALL
-  USING (auth.uid()::text = user_id)
-  WITH CHECK (auth.uid()::text = user_id);
+  USING ((auth.jwt() ->> 'sub') = user_id)
+  WITH CHECK ((auth.jwt() ->> 'sub') = user_id);
 
 -- search_history
 ALTER TABLE search_history ENABLE ROW LEVEL SECURITY;
@@ -28,8 +31,8 @@ ALTER TABLE search_history ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "search_history: 本人のみ全操作可"
   ON search_history
   FOR ALL
-  USING (auth.uid()::text = user_id)
-  WITH CHECK (auth.uid()::text = user_id);
+  USING ((auth.jwt() ->> 'sub') = user_id)
+  WITH CHECK ((auth.jwt() ->> 'sub') = user_id);
 
 -- notification_reads
 ALTER TABLE notification_reads ENABLE ROW LEVEL SECURITY;
@@ -37,5 +40,5 @@ ALTER TABLE notification_reads ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "notification_reads: 本人のみ全操作可"
   ON notification_reads
   FOR ALL
-  USING (auth.uid()::text = user_id)
-  WITH CHECK (auth.uid()::text = user_id);
+  USING ((auth.jwt() ->> 'sub') = user_id)
+  WITH CHECK ((auth.jwt() ->> 'sub') = user_id);

--- a/document/supabase_rls_policies.sql
+++ b/document/supabase_rls_policies.sql
@@ -1,0 +1,41 @@
+-- =============================================================
+-- Supabase RLS (Row Level Security) ポリシー設定
+-- 前提: Supabase Dashboard > Authentication > Third-party Auth
+--       で Firebase プロジェクトを登録済みであること
+-- =============================================================
+
+-- browsing_history
+ALTER TABLE browsing_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "browsing_history: 本人のみ全操作可"
+  ON browsing_history
+  FOR ALL
+  USING (auth.uid()::text = user_id)
+  WITH CHECK (auth.uid()::text = user_id);
+
+-- favorites
+ALTER TABLE favorites ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "favorites: 本人のみ全操作可"
+  ON favorites
+  FOR ALL
+  USING (auth.uid()::text = user_id)
+  WITH CHECK (auth.uid()::text = user_id);
+
+-- search_history
+ALTER TABLE search_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "search_history: 本人のみ全操作可"
+  ON search_history
+  FOR ALL
+  USING (auth.uid()::text = user_id)
+  WITH CHECK (auth.uid()::text = user_id);
+
+-- notification_reads
+ALTER TABLE notification_reads ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "notification_reads: 本人のみ全操作可"
+  ON notification_reads
+  FOR ALL
+  USING (auth.uid()::text = user_id)
+  WITH CHECK (auth.uid()::text = user_id);

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Kenryo Tankyu</string>
+	<string>縣陵探究アーカイブ</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:kenryo_tankyu/core/services/firebase_tracking_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 Future<void> main() async {
@@ -46,6 +47,10 @@ Future<void> main() async {
   await Supabase.initialize(
     url: supabaseUrl,
     anonKey: supabaseAnonKey,
+    // Firebase Third-party Auth: 現在のFirebaseユーザーのIDトークンをSupabaseに渡す
+    accessToken: () async {
+      return await FirebaseAuth.instance.currentUser?.getIdToken();
+    },
   );
 
   final sharedPreferences = await SharedPreferences.getInstance();


### PR DESCRIPTION
## 概要
Supabaseのセキュリティ警告（RLS未設定）への対応と、iOSアプリ表示名の修正。

## 種別
- [x] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
なし

## 変更内容

### Supabase RLS有効化（DBレベルでの保護）
- `browsing_history` / `favorites` / `search_history` / `notification_reads` の4テーブルにRow Level Securityを有効化
- RLSポリシー: `auth.jwt() ->> 'sub' = user_id` で本人のデータのみアクセス可能に
- SQLスクリプトを `document/supabase_rls_policies.sql` に追記

### Firebase Third-party Auth連携（`lib/main.dart`）
- Supabase初期化時に `accessToken` コールバックを追加
- Firebase IDトークンをSupabaseの全リクエストに自動付与し `auth.jwt()` を有効化

### iOSアプリ表示名修正（`ios/Runner/Info.plist`）
- `CFBundleDisplayName` を `Kenryo Tankyu` → `縣陵探究アーカイブ` に変更

## スクリーンショット
なし（セキュリティ設定・表示名変更のため）

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）