### PR TITLE
[UI] iPad対応レイアウト改善

### DIFF
--- a/lib/core/utils/device_type.dart
+++ b/lib/core/utils/device_type.dart
@@ -4,7 +4,7 @@ enum DeviceType { mobile, tablet }
 
 extension DeviceTypeContext on BuildContext {
   DeviceType get deviceType {
-    return MediaQuery.of(this).size.shortestSide >= 600
+    return MediaQuery.sizeOf(this).shortestSide >= 600
         ? DeviceType.tablet
         : DeviceType.mobile;
   }

--- a/lib/core/utils/device_type.dart
+++ b/lib/core/utils/device_type.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+enum DeviceType { mobile, tablet }
+
+extension DeviceTypeContext on BuildContext {
+  DeviceType get deviceType {
+    return MediaQuery.of(this).size.shortestSide >= 600
+        ? DeviceType.tablet
+        : DeviceType.mobile;
+  }
+
+  bool get isTablet => deviceType == DeviceType.tablet;
+}

--- a/lib/features/user_archive/presentation/widgets/history_list.dart
+++ b/lib/features/user_archive/presentation/widgets/history_list.dart
@@ -73,32 +73,42 @@ class _LibraryListState extends ConsumerState<LibraryList> {
           child: Padding(
             padding: const EdgeInsets.all(8.0),
             child: context.isTablet
-                ? GridView.builder(
+                ? CustomScrollView(
                     controller: _scrollController,
                     physics: const AlwaysScrollableScrollPhysics(),
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
-                      crossAxisSpacing: 8,
-                      mainAxisSpacing: 4,
-                      mainAxisExtent: 130,
-                    ),
-                    itemCount: searcheds.length + (hasMore ? 1 : 0),
-                    itemBuilder: (context, index) {
-                      if (index == searcheds.length) {
-                        return const Padding(
-                          padding: EdgeInsets.symmetric(vertical: 16),
-                          child: Center(child: CircularProgressIndicator()),
-                        );
-                      }
-                      final searched = searcheds[index];
-                      return Card(
-                        child: ResultPreviewContent(
-                          searched: searched,
-                          mode: ResultPreviewMode.library,
+                    slivers: [
+                      SliverPadding(
+                        padding: EdgeInsets.zero,
+                        sliver: SliverGrid(
+                          gridDelegate:
+                              const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 2,
+                            crossAxisSpacing: 8,
+                            mainAxisSpacing: 4,
+                            mainAxisExtent: 130,
+                          ),
+                          delegate: SliverChildBuilderDelegate(
+                            (context, index) {
+                              final searched = searcheds[index];
+                              return Card(
+                                child: ResultPreviewContent(
+                                  searched: searched,
+                                  mode: ResultPreviewMode.library,
+                                ),
+                              );
+                            },
+                            childCount: searcheds.length,
+                          ),
                         ),
-                      );
-                    },
+                      ),
+                      if (hasMore)
+                        const SliverToBoxAdapter(
+                          child: Padding(
+                            padding: EdgeInsets.symmetric(vertical: 16),
+                            child: Center(child: CircularProgressIndicator()),
+                          ),
+                        ),
+                    ],
                   )
                 : ListView.separated(
                     controller: _scrollController,

--- a/lib/features/user_archive/presentation/widgets/history_list.dart
+++ b/lib/features/user_archive/presentation/widgets/history_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kenryo_tankyu/core/utils/device_type.dart';
 import 'package:kenryo_tankyu/features/search/presentation/widgets/result_preview_content.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_archive_providers.dart';
 import 'package:kenryo_tankyu/presentation/widget/error_view.dart';
@@ -71,32 +72,60 @@ class _LibraryListState extends ConsumerState<LibraryList> {
           },
           child: Padding(
             padding: const EdgeInsets.all(8.0),
-            child: ListView.separated(
-              controller: _scrollController,
-              physics: const AlwaysScrollableScrollPhysics(),
-              itemCount: searcheds.length + (hasMore ? 1 : 0),
-              itemBuilder: (context, index) {
-                if (index == searcheds.length) {
-                  return const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 16),
-                    child: Center(child: CircularProgressIndicator()),
-                  );
-                }
-                return Consumer(builder: (context, ref, child) {
-                  final searched = searcheds[index];
-                  return ResultPreviewContent(
-                    searched: searched,
-                    mode: ResultPreviewMode.library,
-                  );
-                });
-              },
-              separatorBuilder: (BuildContext context, int index) {
-                return const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Divider(),
-                );
-              },
-            ),
+            child: context.isTablet
+                ? GridView.builder(
+                    controller: _scrollController,
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      crossAxisSpacing: 8,
+                      mainAxisSpacing: 4,
+                      childAspectRatio: 2.2,
+                    ),
+                    itemCount: searcheds.length + (hasMore ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      if (index == searcheds.length) {
+                        return const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 16),
+                          child: Center(child: CircularProgressIndicator()),
+                        );
+                      }
+                      final searched = searcheds[index];
+                      return Card(
+                        child: ResultPreviewContent(
+                          searched: searched,
+                          mode: ResultPreviewMode.library,
+                        ),
+                      );
+                    },
+                  )
+                : ListView.separated(
+                    controller: _scrollController,
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    itemCount: searcheds.length + (hasMore ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      if (index == searcheds.length) {
+                        return const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 16),
+                          child: Center(child: CircularProgressIndicator()),
+                        );
+                      }
+                      return Consumer(builder: (context, ref, child) {
+                        final searched = searcheds[index];
+                        return ResultPreviewContent(
+                          searched: searched,
+                          mode: ResultPreviewMode.library,
+                        );
+                      });
+                    },
+                    separatorBuilder: (BuildContext context, int index) {
+                      return const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 8.0),
+                        child: Divider(),
+                      );
+                    },
+                  ),
           ),
         );
       },

--- a/lib/features/user_archive/presentation/widgets/history_list.dart
+++ b/lib/features/user_archive/presentation/widgets/history_list.dart
@@ -81,7 +81,7 @@ class _LibraryListState extends ConsumerState<LibraryList> {
                       crossAxisCount: 2,
                       crossAxisSpacing: 8,
                       mainAxisSpacing: 4,
-                      mainAxisExtent: 155,
+                      mainAxisExtent: 130,
                     ),
                     itemCount: searcheds.length + (hasMore ? 1 : 0),
                     itemBuilder: (context, index) {

--- a/lib/features/user_archive/presentation/widgets/history_list.dart
+++ b/lib/features/user_archive/presentation/widgets/history_list.dart
@@ -81,7 +81,7 @@ class _LibraryListState extends ConsumerState<LibraryList> {
                       crossAxisCount: 2,
                       crossAxisSpacing: 8,
                       mainAxisSpacing: 4,
-                      childAspectRatio: 2.2,
+                      mainAxisExtent: 155,
                     ),
                     itemCount: searcheds.length + (hasMore ? 1 : 0),
                     itemBuilder: (context, index) {

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -29,37 +29,40 @@ class _StatsLayout extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (context.isTablet) {
-      return Row(
-        children: [
-          Expanded(
-            flex: 2,
-            child: _StreakCard(streakDays: stats?.streakDays),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: _CountCard(
-              label: '今日',
-              count: stats?.todayViews,
-              icon: Icons.today_outlined,
+      return IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              flex: 2,
+              child: _StreakCard(streakDays: stats?.streakDays),
             ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: _CountCard(
-              label: '7日間',
-              count: stats?.weekViews,
-              icon: Icons.date_range_outlined,
+            const SizedBox(width: 8),
+            Expanded(
+              child: _CountCard(
+                label: '今日',
+                count: stats?.todayViews,
+                icon: Icons.today_outlined,
+              ),
             ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: _CountCard(
-              label: '累計',
-              count: stats?.totalViews,
-              icon: Icons.library_books_outlined,
+            const SizedBox(width: 8),
+            Expanded(
+              child: _CountCard(
+                label: '7日間',
+                count: stats?.weekViews,
+                icon: Icons.date_range_outlined,
+              ),
             ),
-          ),
-        ],
+            const SizedBox(width: 8),
+            Expanded(
+              child: _CountCard(
+                label: '累計',
+                count: stats?.totalViews,
+                icon: Icons.library_books_outlined,
+              ),
+            ),
+          ],
+        ),
       );
     }
 

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:kenryo_tankyu/core/utils/device_type.dart';
 import 'package:kenryo_tankyu/features/user_archive/domain/models/user_stats.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_stats_provider.dart';
@@ -36,7 +35,7 @@ class _StatsLayout extends StatelessWidget {
             flex: 2,
             child: _StreakCard(streakDays: stats?.streakDays),
           ),
-          SizedBox(width: 8.w),
+          const SizedBox(width: 8),
           Expanded(
             child: _CountCard(
               label: '今日',
@@ -44,7 +43,7 @@ class _StatsLayout extends StatelessWidget {
               icon: Icons.today_outlined,
             ),
           ),
-          SizedBox(width: 8.w),
+          const SizedBox(width: 8),
           Expanded(
             child: _CountCard(
               label: '7日間',
@@ -52,7 +51,7 @@ class _StatsLayout extends StatelessWidget {
               icon: Icons.date_range_outlined,
             ),
           ),
-          SizedBox(width: 8.w),
+          const SizedBox(width: 8),
           Expanded(
             child: _CountCard(
               label: '累計',
@@ -68,7 +67,7 @@ class _StatsLayout extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _StreakCard(streakDays: stats?.streakDays),
-        SizedBox(height: 8.h),
+        const SizedBox(height: 8),
         Row(
           children: [
             Expanded(
@@ -78,7 +77,7 @@ class _StatsLayout extends StatelessWidget {
                 icon: Icons.today_outlined,
               ),
             ),
-            SizedBox(width: 8.w),
+            const SizedBox(width: 8),
             Expanded(
               child: _CountCard(
                 label: '7日間',
@@ -86,7 +85,7 @@ class _StatsLayout extends StatelessWidget {
                 icon: Icons.date_range_outlined,
               ),
             ),
-            SizedBox(width: 8.w),
+            const SizedBox(width: 8),
             Expanded(
               child: _CountCard(
                 label: '累計',
@@ -115,15 +114,15 @@ class _StreakCard extends StatelessWidget {
     return Card(
       color: colorScheme.primaryContainer,
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         child: Row(
           children: [
             Image.asset(
               'assets/images/app_icon.png',
-              width: 28.w,
-              height: 28.h,
+              width: 28,
+              height: 28,
             ),
-            SizedBox(width: 8.w),
+            const SizedBox(width: 8),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -131,7 +130,7 @@ class _StreakCard extends StatelessWidget {
                   Text(
                     isLoading ? '読み込み中...' : '$days日連続閲覧中！',
                     style: TextStyle(
-                      fontSize: 15.sp,
+                      fontSize: 15,
                       fontWeight: FontWeight.bold,
                       color: colorScheme.onPrimaryContainer,
                     ),
@@ -139,7 +138,7 @@ class _StreakCard extends StatelessWidget {
                   Text(
                     '毎日続けて探究を深めよう',
                     style: TextStyle(
-                      fontSize: 11.sp,
+                      fontSize: 11,
                       color:
                           colorScheme.onPrimaryContainer.withValues(alpha: 0.7),
                     ),
@@ -212,19 +211,18 @@ class _AnimatedDaysCounterState extends State<_AnimatedDaysCounter>
             Text(
               '${_animation.value.toInt()}',
               style: TextStyle(
-                fontSize: 32.sp,
+                fontSize: 32,
                 fontWeight: FontWeight.bold,
                 color: colorScheme.primary,
               ),
             ),
-            Padding(
-              padding: EdgeInsets.only(bottom: 4.h),
+            const Padding(
+              padding: EdgeInsets.only(bottom: 4),
               child: Text(
                 '日',
                 style: TextStyle(
-                  fontSize: 13.sp,
+                  fontSize: 13,
                   fontWeight: FontWeight.bold,
-                  color: colorScheme.primary,
                 ),
               ),
             ),
@@ -292,16 +290,16 @@ class _CountCardState extends State<_CountCard>
 
     return Card(
       child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 12.h, horizontal: 8.w),
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
         child: Column(
           children: [
-            Icon(widget.icon, size: 20.sp, color: colorScheme.primary),
-            SizedBox(height: 4.h),
+            Icon(widget.icon, size: 20, color: colorScheme.primary),
+            const SizedBox(height: 4),
             isLoading
-                ? SizedBox(
-                    height: 24.h,
-                    width: 24.w,
-                    child: const CircularProgressIndicator(strokeWidth: 2),
+                ? const SizedBox(
+                    height: 24,
+                    width: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : AnimatedBuilder(
                     animation: _animation,
@@ -313,17 +311,17 @@ class _CountCardState extends State<_CountCard>
                           Text(
                             '${_animation.value.toInt()}',
                             style: TextStyle(
-                              fontSize: 22.sp,
+                              fontSize: 22,
                               fontWeight: FontWeight.bold,
                               color: colorScheme.onSurface,
                             ),
                           ),
                           Padding(
-                            padding: EdgeInsets.only(bottom: 2.h),
+                            padding: const EdgeInsets.only(bottom: 2),
                             child: Text(
                               '件',
                               style: TextStyle(
-                                fontSize: 11.sp,
+                                fontSize: 11,
                                 color: colorScheme.onSurfaceVariant,
                               ),
                             ),
@@ -332,11 +330,11 @@ class _CountCardState extends State<_CountCard>
                       );
                     },
                   ),
-            SizedBox(height: 2.h),
+            const SizedBox(height: 2),
             Text(
               widget.label,
               style: TextStyle(
-                fontSize: 11.sp,
+                fontSize: 11,
                 color: colorScheme.onSurfaceVariant,
               ),
             ),

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -119,6 +119,7 @@ class _StreakCard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Image.asset(
               'assets/images/app_icon.png',
@@ -129,6 +130,7 @@ class _StreakCard extends StatelessWidget {
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
                     isLoading ? '読み込み中...' : '$days日連続閲覧中！',

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:kenryo_tankyu/core/utils/device_type.dart';
 import 'package:kenryo_tankyu/features/user_archive/domain/models/user_stats.dart';
 import 'package:kenryo_tankyu/features/user_archive/presentation/providers/user_stats_provider.dart';
 
@@ -28,6 +29,41 @@ class _StatsLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (context.isTablet) {
+      return Row(
+        children: [
+          Expanded(
+            flex: 2,
+            child: _StreakCard(streakDays: stats?.streakDays),
+          ),
+          SizedBox(width: 8.w),
+          Expanded(
+            child: _CountCard(
+              label: '今日',
+              count: stats?.todayViews,
+              icon: Icons.today_outlined,
+            ),
+          ),
+          SizedBox(width: 8.w),
+          Expanded(
+            child: _CountCard(
+              label: '7日間',
+              count: stats?.weekViews,
+              icon: Icons.date_range_outlined,
+            ),
+          ),
+          SizedBox(width: 8.w),
+          Expanded(
+            child: _CountCard(
+              label: '累計',
+              count: stats?.totalViews,
+              icon: Icons.library_books_outlined,
+            ),
+          ),
+        ],
+      );
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/features/user_archive/presentation/widgets/user_stats_section.dart
+++ b/lib/features/user_archive/presentation/widgets/user_stats_section.dart
@@ -297,6 +297,7 @@ class _CountCardState extends State<_CountCard>
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
         child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(widget.icon, size: 20, color: colorScheme.primary),
             const SizedBox(height: 4),

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -86,22 +86,25 @@ class _HomePageState extends ConsumerState<HomePage> {
                         return Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Expanded(
-                              child: Card(
-                                child: ResultPreviewContent(
-                                  searched: data[0],
-                                  mode: ResultPreviewMode.search,
+                            if (data.isNotEmpty)
+                              Expanded(
+                                child: Card(
+                                  child: ResultPreviewContent(
+                                    searched: data[0],
+                                    mode: ResultPreviewMode.search,
+                                  ),
                                 ),
                               ),
-                            ),
                             const SizedBox(width: 8),
                             Expanded(
-                              child: Card(
-                                child: ResultPreviewContent(
-                                  searched: data[1],
-                                  mode: ResultPreviewMode.search,
-                                ),
-                              ),
+                              child: data.length > 1
+                                  ? Card(
+                                      child: ResultPreviewContent(
+                                        searched: data[1],
+                                        mode: ResultPreviewMode.search,
+                                      ),
+                                    )
+                                  : const SizedBox.shrink(),
                             ),
                           ],
                         );

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import "package:kenryo_tankyu/core/constants/app_unique_value.dart";
+import 'package:kenryo_tankyu/core/utils/device_type.dart';
 import 'package:kenryo_tankyu/features/search/presentation/widgets/result_preview_content.dart';
 import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
 import 'package:kenryo_tankyu/features/auth/presentation/providers/auth_provider.dart';
@@ -81,6 +82,30 @@ class _HomePageState extends ConsumerState<HomePage> {
                           },
                         ),
                     data: (data) {
+                      if (context.isTablet) {
+                        return Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Expanded(
+                              child: Card(
+                                child: ResultPreviewContent(
+                                  searched: data[0],
+                                  mode: ResultPreviewMode.search,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Card(
+                                child: ResultPreviewContent(
+                                  searched: data[1],
+                                  mode: ResultPreviewMode.search,
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      }
                       return Column(
                         children: [
                           Card(


### PR DESCRIPTION
## 概要
iPhoneを基準に作られていたUIをiPadでも崩れないように対応。汎用的なデバイス判定ユーティリティを追加し、各画面のレイアウトをiPad幅で適切に切り替えるようにした。

## 種別
- [x] 機能追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
なし

## 変更内容
- `core/utils/device_type.dart` を新規追加
  - `BuildContext` 拡張として `isTablet` / `deviceType` を提供
  - `MediaQuery.shortestSide >= 600` でiPad判定
- `UserStatsSection`（ホーム画面）
  - iPad: StreakCard + 3つのCountCardを横1行に統一（`IntrinsicHeight` + `CrossAxisAlignment.stretch` で高さ揃え、Cardコンテンツは縦中央揃え）
  - `flutter_screenutil` の `.sp` を全て固定値に変更（iPadで約2倍スケールされ文字が折り返す問題を修正）
- `HomePage`（ホーム画面）
  - iPad: 「今日のあなたに」カード2枚を横2列表示
- `LibraryList`（ライブラリ画面）
  - iPad: `GridView.builder` 2列レイアウト（`mainAxisExtent: 130` で適切なカード高さに設定）

## スクリーンショット
実機（iPad）で確認済み

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）