### PR TITLE
[ShareHelper] iPadで共有シートが表示されない問題を修正

### DIFF
--- a/lib/features/research_work/presentation/screens/result_page.dart
+++ b/lib/features/research_work/presentation/screens/result_page.dart
@@ -151,6 +151,9 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
     if (!mounted) return;
     final searchedAsync = ref.read(searchedItemProvider(widget.documentID));
     final searched = searchedAsync.hasValue ? searchedAsync.requireValue : null;
+    // ダイアログのcontextはpop後に無効になるため、共有シートのアンカー位置には
+    // 画面(State)側の安定したcontextを使う。
+    final pageContext = context;
     showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -163,7 +166,7 @@ class _ResultPageMainState extends ConsumerState<ResultPage> {
               TextButton(
                 onPressed: () async {
                   Navigator.of(context).pop();
-                  await shareSearched(searched);
+                  await shareSearched(searched, context: pageContext);
                 },
                 child: const Text('代わりに共有する...'),
               ),

--- a/lib/features/research_work/presentation/utils/share_helper.dart
+++ b/lib/features/research_work/presentation/utils/share_helper.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 
@@ -13,8 +14,21 @@ String buildShareText(Searched searched) {
       '$url';
 }
 
-Future<void> shareSearched(Searched searched) async {
+Future<void> shareSearched(Searched searched, {BuildContext? context}) async {
   await SharePlus.instance.share(
-    ShareParams(text: buildShareText(searched)),
+    ShareParams(
+      text: buildShareText(searched),
+      // iPadでは共有シートがポップオーバー表示になるため、アンカー位置を渡さないと
+      // 何も表示されない。呼び出し元WidgetのRectを基準位置として指定する。
+      sharePositionOrigin: _sharePositionOrigin(context),
+    ),
   );
+}
+
+/// 共有シートのポップオーバー表示用のアンカー位置（iPad向け）を返す。
+Rect? _sharePositionOrigin(BuildContext? context) {
+  if (context == null) return null;
+  final box = context.findRenderObject() as RenderBox?;
+  if (box == null || !box.hasSize) return null;
+  return box.localToGlobal(Offset.zero) & box.size;
 }

--- a/lib/features/research_work/presentation/utils/share_helper.dart
+++ b/lib/features/research_work/presentation/utils/share_helper.dart
@@ -27,8 +27,10 @@ Future<void> shareSearched(Searched searched, {BuildContext? context}) async {
 
 /// 共有シートのポップオーバー表示用のアンカー位置（iPad向け）を返す。
 Rect? _sharePositionOrigin(BuildContext? context) {
-  if (context == null) return null;
-  final box = context.findRenderObject() as RenderBox?;
-  if (box == null || !box.hasSize) return null;
-  return box.localToGlobal(Offset.zero) & box.size;
+  // アンマウント済みのcontextでfindRenderObject()を呼ぶとAssertionErrorで
+  // クラッシュするため、mountedを確認してからアクセスする。
+  if (context == null || !context.mounted) return null;
+  final renderObject = context.findRenderObject();
+  if (renderObject is! RenderBox || !renderObject.hasSize) return null;
+  return renderObject.localToGlobal(Offset.zero) & renderObject.size;
 }

--- a/lib/features/research_work/presentation/widgets/header_for_result.dart
+++ b/lib/features/research_work/presentation/widgets/header_for_result.dart
@@ -57,7 +57,8 @@ class HeaderForResultPage extends ConsumerWidget
                         child: const Text('情報の変更を提案'),
                       ),
                       PopupMenuItem(
-                        onTap: () async => shareSearched(searched),
+                        onTap: () async =>
+                            shareSearched(searched, context: context),
                         child: const Text('共有する...'),
                       ),
                     ];


### PR DESCRIPTION
## 概要
iPadで探究作品の「共有する...」を押しても共有シートが表示されない不具合を修正する。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #

## 変更内容
- iPadでは共有シート（`UIActivityViewController`）がポップオーバー表示になり、`ShareParams.sharePositionOrigin`（アンカー位置）を渡さないと表示されない。iPhoneは画面下からのモーダル表示のため不要で、問題なく動作していた。
- `shareSearched` に optional な `BuildContext? context` を追加し、呼び出し元Widgetの `RenderBox` から `Rect` を計算して `sharePositionOrigin` に渡すよう修正。context が null / 未マウントでも安全に動くようガードを追加。
- 呼び出し元2箇所（`header_for_result.dart` のPopupMenu、`result_page.dart` のスクショ検知ダイアログ）から `context` を渡すよう更新。スクショ検知ダイアログ側はpop後にダイアログのcontextが無効になるため、画面(State)側の安定したcontextを渡している。

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)