### PR TITLE
[KRGP] KRGP受賞作品ページを新規追加

### DIFF
--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -19,6 +19,7 @@ import 'package:kenryo_tankyu/features/search/presentation/screens/search_page.d
 import 'package:kenryo_tankyu/features/search/presentation/screens/sub_category_select_page.dart';
 
 // Features
+import 'package:kenryo_tankyu/features/krgp/presentation/screens/krgp_awards_page.dart';
 import 'package:kenryo_tankyu/features/notification/presentation/screens/notification_page.dart';
 import 'package:kenryo_tankyu/features/research_work/presentation/screens/result_page.dart';
 import 'package:kenryo_tankyu/features/settings/presentation/screens/settings_page.dart';
@@ -144,6 +145,10 @@ final routesProvider = Provider<GoRouter>((ref) {
       ),
 
       // ─── その他の機能 ─────────────────────────────────────────
+      GoRoute(
+        path: '/krgp',
+        builder: (context, state) => const KrgpAwardsPage(),
+      ),
       GoRoute(
         path: '/settings',
         builder: (context, state) => const SettingsPage(),

--- a/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
+++ b/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
@@ -1,0 +1,27 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'krgp_remote_data_source.g.dart';
+
+// Firestore path: collection 'krgp', subcollection 'awards'
+// krgp/{year}/awards/{docId} → collectionGroup('awards')
+// または collection('krgp') の場合はここを変更
+const _kKrgpCollection = 'krgp';
+
+@riverpod
+KrgpRemoteDataSource krgpRemoteDataSource(Ref ref) {
+  return KrgpRemoteDataSource(FirebaseFirestore.instance);
+}
+
+class KrgpRemoteDataSource {
+  final FirebaseFirestore _firestore;
+  const KrgpRemoteDataSource(this._firestore);
+
+  Future<List<Searched>> fetchAllAwards() async {
+    final snapshot = await _firestore.collection(_kKrgpCollection).get();
+    return snapshot.docs.map((doc) {
+      return Searched.fromFirestore(doc, false);
+    }).toList();
+  }
+}

--- a/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
+++ b/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
@@ -24,20 +24,8 @@ class KrgpRemoteDataSource {
 
     for (final item in rawWorks) {
       try {
-        final map = Map<String, dynamic>.from(item as Map);
-        final documentID = (map['documentID'] as num?)?.toInt() ?? 0;
-        // documentID は fromJson で無視されるフィールドなので copyWith で後付け
-        map.putIfAbsent('likes', () => 0);
-        map.putIfAbsent('existsSlide', () => false);
-        map.putIfAbsent('existsReport', () => false);
-        map.putIfAbsent('existsThesis', () => false);
-        map.putIfAbsent('existsPoster', () => false);
-        final searched = Searched.fromJson(map);
-        results.add(searched.copyWith(
-          documentID: documentID,
-          isFavorite: false,
-          isCached: false,
-        ));
+        results
+            .add(Searched.fromKrgpDb(Map<String, dynamic>.from(item as Map)));
       } catch (e) {
         debugPrint('[KrgpDataSource] parse error: $e\nitem: $item');
       }

--- a/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
+++ b/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
@@ -1,13 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'krgp_remote_data_source.g.dart';
-
-// Firestore path: collection 'krgp', subcollection 'awards'
-// krgp/{year}/awards/{docId} → collectionGroup('awards')
-// または collection('krgp') の場合はここを変更
-const _kKrgpCollection = 'krgp';
 
 @riverpod
 KrgpRemoteDataSource krgpRemoteDataSource(Ref ref) {
@@ -19,9 +15,57 @@ class KrgpRemoteDataSource {
   const KrgpRemoteDataSource(this._firestore);
 
   Future<List<Searched>> fetchAllAwards() async {
-    final snapshot = await _firestore.collection(_kKrgpCollection).get();
-    return snapshot.docs.map((doc) {
-      return Searched.fromFirestore(doc, false);
-    }).toList();
+    final snapshot = await _firestore.collection('krgp').get();
+    final results = <Searched>[];
+    for (final doc in snapshot.docs) {
+      try {
+        final data = Map<String, dynamic>.from(doc.data());
+        _normalizeData(data, doc.id);
+        final searched = Searched.fromJson(data);
+        final documentID = int.tryParse(doc.id) ?? 0;
+        results.add(searched.copyWith(
+          documentID: documentID,
+          isFavorite: false,
+          isCached: false,
+        ));
+      } catch (e) {
+        debugPrint('[KrgpDataSource] doc ${doc.id} parse error: $e');
+      }
+    }
+    return results;
+  }
+
+  // Firestoreの型ゆらぎを吸収する
+  void _normalizeData(Map<String, dynamic> data, String docId) {
+    // awardType が String で来た場合 ("grand"/"excellent" 等) を int に変換
+    final rawAwardType = data['awardType'];
+    if (rawAwardType is String) {
+      final byName = {
+        'grand': 1,
+        'excellent': 2,
+        'encouragement': 3,
+        'honorable': 4,
+      };
+      data['awardType'] = byName[rawAwardType];
+    }
+
+    // enterYear が String で来た場合を int に変換
+    final rawEnterYear = data['enterYear'];
+    if (rawEnterYear is String) {
+      data['enterYear'] = int.tryParse(rawEnterYear);
+    }
+
+    // likes が存在しない場合はデフォルト値
+    data.putIfAbsent('likes', () => 0);
+
+    // exist系フラグが存在しない場合はデフォルト値
+    for (final key in [
+      'existsSlide',
+      'existsReport',
+      'existsThesis',
+      'existsPoster',
+    ]) {
+      data.putIfAbsent(key, () => false);
+    }
   }
 }

--- a/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
+++ b/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
@@ -15,57 +15,34 @@ class KrgpRemoteDataSource {
   const KrgpRemoteDataSource(this._firestore);
 
   Future<List<Searched>> fetchAllAwards() async {
-    final snapshot = await _firestore.collection('krgp').get();
+    final doc = await _firestore.collection('krgp').doc('awards').get();
+    final docData = doc.data();
+    if (docData == null) return [];
+
+    final rawWorks = docData['works'] as List<dynamic>? ?? [];
     final results = <Searched>[];
-    for (final doc in snapshot.docs) {
+
+    for (final item in rawWorks) {
       try {
-        final data = Map<String, dynamic>.from(doc.data());
-        _normalizeData(data, doc.id);
-        final searched = Searched.fromJson(data);
-        final documentID = int.tryParse(doc.id) ?? 0;
+        final map = Map<String, dynamic>.from(item as Map);
+        final documentID = (map['documentID'] as num?)?.toInt() ?? 0;
+        // documentID は fromJson で無視されるフィールドなので copyWith で後付け
+        map.putIfAbsent('likes', () => 0);
+        map.putIfAbsent('existsSlide', () => false);
+        map.putIfAbsent('existsReport', () => false);
+        map.putIfAbsent('existsThesis', () => false);
+        map.putIfAbsent('existsPoster', () => false);
+        final searched = Searched.fromJson(map);
         results.add(searched.copyWith(
           documentID: documentID,
           isFavorite: false,
           isCached: false,
         ));
       } catch (e) {
-        debugPrint('[KrgpDataSource] doc ${doc.id} parse error: $e');
+        debugPrint('[KrgpDataSource] parse error: $e\nitem: $item');
       }
     }
+
     return results;
-  }
-
-  // Firestoreの型ゆらぎを吸収する
-  void _normalizeData(Map<String, dynamic> data, String docId) {
-    // awardType が String で来た場合 ("grand"/"excellent" 等) を int に変換
-    final rawAwardType = data['awardType'];
-    if (rawAwardType is String) {
-      final byName = {
-        'grand': 1,
-        'excellent': 2,
-        'encouragement': 3,
-        'honorable': 4,
-      };
-      data['awardType'] = byName[rawAwardType];
-    }
-
-    // enterYear が String で来た場合を int に変換
-    final rawEnterYear = data['enterYear'];
-    if (rawEnterYear is String) {
-      data['enterYear'] = int.tryParse(rawEnterYear);
-    }
-
-    // likes が存在しない場合はデフォルト値
-    data.putIfAbsent('likes', () => 0);
-
-    // exist系フラグが存在しない場合はデフォルト値
-    for (final key in [
-      'existsSlide',
-      'existsReport',
-      'existsThesis',
-      'existsPoster',
-    ]) {
-      data.putIfAbsent(key, () => false);
-    }
   }
 }

--- a/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
+++ b/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
@@ -24,8 +24,11 @@ class KrgpRemoteDataSource {
 
     for (final item in rawWorks) {
       try {
-        results
-            .add(Searched.fromKrgpDb(Map<String, dynamic>.from(item as Map)));
+        if (item is Map) {
+          results.add(Searched.fromKrgpDb(Map<String, dynamic>.from(item)));
+        } else {
+          debugPrint('[KrgpDataSource] item is not a Map: $item');
+        }
       } catch (e) {
         debugPrint('[KrgpDataSource] parse error: $e\nitem: $item');
       }

--- a/lib/features/krgp/data/datasources/krgp_remote_data_source.g.dart
+++ b/lib/features/krgp/data/datasources/krgp_remote_data_source.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'krgp_remote_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(krgpRemoteDataSource)
+final krgpRemoteDataSourceProvider = KrgpRemoteDataSourceProvider._();
+
+final class KrgpRemoteDataSourceProvider extends $FunctionalProvider<
+    KrgpRemoteDataSource,
+    KrgpRemoteDataSource,
+    KrgpRemoteDataSource> with $Provider<KrgpRemoteDataSource> {
+  KrgpRemoteDataSourceProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'krgpRemoteDataSourceProvider',
+          isAutoDispose: true,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$krgpRemoteDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<KrgpRemoteDataSource> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  KrgpRemoteDataSource create(Ref ref) {
+    return krgpRemoteDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(KrgpRemoteDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<KrgpRemoteDataSource>(value),
+    );
+  }
+}
+
+String _$krgpRemoteDataSourceHash() =>
+    r'63367e30a8c2397a9cb960e9062dd4a6dd82ac23';

--- a/lib/features/krgp/presentation/providers/krgp_provider.dart
+++ b/lib/features/krgp/presentation/providers/krgp_provider.dart
@@ -1,0 +1,68 @@
+import 'package:kenryo_tankyu/core/constants/work/award_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
+import 'package:kenryo_tankyu/features/krgp/data/datasources/krgp_remote_data_source.dart';
+import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'krgp_provider.g.dart';
+
+enum KrgpSortMode { year, award }
+
+/// Firestoreから全KRGP受賞作品を1度だけ取得してキャッシュする
+@Riverpod(keepAlive: true)
+Future<List<Searched>> krgpAwards(Ref ref) async {
+  final dataSource = ref.watch(krgpRemoteDataSourceProvider);
+  return dataSource.fetchAllAwards();
+}
+
+/// year モード: enterYear → [awardType → [awardName → works]]
+Map<EnterYear, Map<AwardType, Map<String?, List<Searched>>>> groupByYear(
+    List<Searched> works) {
+  final result = <EnterYear, Map<AwardType, Map<String?, List<Searched>>>>{};
+
+  for (final year in EnterYear.values.where((y) => y != EnterYear.undefined)) {
+    final byYear = works.where((w) => w.enterYear == year).toList();
+    if (byYear.isEmpty) continue;
+
+    final byType = <AwardType, Map<String?, List<Searched>>>{};
+    for (final type in AwardType.values) {
+      final byAwardType = byYear.where((w) => w.awardType == type).toList();
+      if (byAwardType.isEmpty) continue;
+
+      final byName = <String?, List<Searched>>{};
+      for (final work in byAwardType) {
+        final key = work.awardName?.trim().isEmpty ?? true
+            ? null
+            : work.awardName?.trim();
+        byName.putIfAbsent(key, () => []).add(work);
+      }
+      byType[type] = byName;
+    }
+    if (byType.isNotEmpty) result[year] = byType;
+  }
+
+  return result;
+}
+
+/// award モード: awardType → [awardName → [enterYear → works]]
+Map<AwardType, Map<String?, Map<EnterYear, List<Searched>>>> groupByAward(
+    List<Searched> works) {
+  final result = <AwardType, Map<String?, Map<EnterYear, List<Searched>>>>{};
+
+  for (final type in AwardType.values) {
+    final byType = works.where((w) => w.awardType == type).toList();
+    if (byType.isEmpty) continue;
+
+    final byName = <String?, Map<EnterYear, List<Searched>>>{};
+    for (final work in byType) {
+      final nameKey = work.awardName?.trim().isEmpty ?? true
+          ? null
+          : work.awardName?.trim();
+      final byYear = byName.putIfAbsent(nameKey, () => {});
+      byYear.putIfAbsent(work.enterYear, () => []).add(work);
+    }
+    result[type] = byName;
+  }
+
+  return result;
+}

--- a/lib/features/krgp/presentation/providers/krgp_provider.g.dart
+++ b/lib/features/krgp/presentation/providers/krgp_provider.g.dart
@@ -1,0 +1,48 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'krgp_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Firestoreから全KRGP受賞作品を1度だけ取得してキャッシュする
+
+@ProviderFor(krgpAwards)
+final krgpAwardsProvider = KrgpAwardsProvider._();
+
+/// Firestoreから全KRGP受賞作品を1度だけ取得してキャッシュする
+
+final class KrgpAwardsProvider extends $FunctionalProvider<
+        AsyncValue<List<Searched>>, List<Searched>, FutureOr<List<Searched>>>
+    with $FutureModifier<List<Searched>>, $FutureProvider<List<Searched>> {
+  /// Firestoreから全KRGP受賞作品を1度だけ取得してキャッシュする
+  KrgpAwardsProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'krgpAwardsProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$krgpAwardsHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<Searched>> $createElement(
+          $ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<Searched>> create(Ref ref) {
+    return krgpAwards(ref);
+  }
+}
+
+String _$krgpAwardsHash() => r'602632ca1f1b6310f05c72241ec5d356edfc3667';

--- a/lib/features/krgp/presentation/screens/krgp_awards_page.dart
+++ b/lib/features/krgp/presentation/screens/krgp_awards_page.dart
@@ -1,0 +1,292 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kenryo_tankyu/core/constants/work/award_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
+import 'package:kenryo_tankyu/features/krgp/presentation/providers/krgp_provider.dart';
+import 'package:kenryo_tankyu/features/research_work/domain/models/searched.dart';
+import 'package:kenryo_tankyu/features/search/presentation/widgets/result_preview_content.dart';
+import 'package:kenryo_tankyu/presentation/widget/error_view.dart';
+
+class KrgpAwardsPage extends ConsumerStatefulWidget {
+  const KrgpAwardsPage({super.key});
+
+  @override
+  ConsumerState<KrgpAwardsPage> createState() => _KrgpAwardsPageState();
+}
+
+class _KrgpAwardsPageState extends ConsumerState<KrgpAwardsPage>
+    with TickerProviderStateMixin {
+  KrgpSortMode _sortMode = KrgpSortMode.year;
+  TabController? _tabController;
+
+  static const _years = [
+    EnterYear.enter2024,
+    EnterYear.enter2023,
+    EnterYear.enter2022,
+    EnterYear.enter2021,
+    EnterYear.enter2020,
+  ];
+
+  @override
+  void dispose() {
+    _tabController?.dispose();
+    super.dispose();
+  }
+
+  void _buildTabController(int length) {
+    _tabController?.dispose();
+    _tabController = TabController(length: length, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncWorks = ref.watch(krgpAwardsProvider);
+
+    return asyncWorks.when(
+      loading: () => Scaffold(
+        appBar: _buildAppBar(context, null),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, st) => Scaffold(
+        appBar: _buildAppBar(context, null),
+        body: CommonErrorView(
+          error: e,
+          onRetry: () => ref.invalidate(krgpAwardsProvider),
+        ),
+      ),
+      data: (works) {
+        if (_sortMode == KrgpSortMode.year) {
+          final grouped = groupByYear(works);
+          final availableYears =
+              _years.where((y) => grouped.containsKey(y)).toList();
+          if (_tabController == null ||
+              _tabController!.length != availableYears.length) {
+            _buildTabController(availableYears.length);
+          }
+          return Scaffold(
+            appBar: _buildAppBar(context, _tabController),
+            body: availableYears.isEmpty
+                ? const Center(child: Text('データがありません'))
+                : Column(
+                    children: [
+                      TabBar(
+                        controller: _tabController,
+                        isScrollable: true,
+                        tabAlignment: TabAlignment.start,
+                        tabs: availableYears
+                            .map((y) => Tab(text: '${y.displayName}年度入学'))
+                            .toList(),
+                      ),
+                      Expanded(
+                        child: TabBarView(
+                          controller: _tabController,
+                          children: availableYears
+                              .map((y) => _YearTabContent(
+                                    yearData: grouped[y]!,
+                                  ))
+                              .toList(),
+                        ),
+                      ),
+                    ],
+                  ),
+          );
+        } else {
+          final grouped = groupByAward(works);
+          final availableTypes =
+              AwardType.values.where((t) => grouped.containsKey(t)).toList();
+          if (_tabController == null ||
+              _tabController!.length != availableTypes.length) {
+            _buildTabController(availableTypes.length);
+          }
+          return Scaffold(
+            appBar: _buildAppBar(context, _tabController),
+            body: availableTypes.isEmpty
+                ? const Center(child: Text('データがありません'))
+                : Column(
+                    children: [
+                      TabBar(
+                        controller: _tabController,
+                        isScrollable: true,
+                        tabAlignment: TabAlignment.start,
+                        tabs: availableTypes
+                            .map((t) => Tab(text: t.displayName))
+                            .toList(),
+                      ),
+                      Expanded(
+                        child: TabBarView(
+                          controller: _tabController,
+                          children: availableTypes
+                              .map((t) => _AwardTabContent(
+                                    awardData: grouped[t]!,
+                                  ))
+                              .toList(),
+                        ),
+                      ),
+                    ],
+                  ),
+          );
+        }
+      },
+    );
+  }
+
+  AppBar _buildAppBar(BuildContext context, TabController? tabController) {
+    return AppBar(
+      title: const Text('KRGP受賞作品'),
+      actions: [
+        PopupMenuButton<KrgpSortMode>(
+          icon: const Icon(Icons.sort),
+          tooltip: '並び替え',
+          initialValue: _sortMode,
+          onSelected: (mode) {
+            if (mode == _sortMode) return;
+            setState(() {
+              _sortMode = mode;
+              _tabController = null;
+            });
+          },
+          itemBuilder: (context) => [
+            const PopupMenuItem(
+              value: KrgpSortMode.year,
+              child: Text('年度ごと'),
+            ),
+            const PopupMenuItem(
+              value: KrgpSortMode.award,
+              child: Text('賞ごと'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _YearTabContent extends StatelessWidget {
+  final Map<AwardType, Map<String?, List<Searched>>> yearData;
+  const _YearTabContent({required this.yearData});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <Widget>[];
+
+    for (final type in AwardType.values) {
+      final byName = yearData[type];
+      if (byName == null) continue;
+
+      items.add(_SectionHeader(label: type.displayName, isTop: items.isEmpty));
+
+      for (final entry in byName.entries) {
+        if (entry.key != null) {
+          items.add(_SubSectionHeader(label: entry.key!));
+        }
+        for (final work in entry.value) {
+          items.add(_WorkCard(work: work));
+        }
+      }
+    }
+
+    return ListView(children: items);
+  }
+}
+
+class _AwardTabContent extends StatelessWidget {
+  final Map<String?, Map<EnterYear, List<Searched>>> awardData;
+  const _AwardTabContent({required this.awardData});
+
+  @override
+  Widget build(BuildContext context) {
+    const yearsDesc = [
+      EnterYear.enter2024,
+      EnterYear.enter2023,
+      EnterYear.enter2022,
+      EnterYear.enter2021,
+      EnterYear.enter2020,
+    ];
+
+    final items = <Widget>[];
+    var isFirst = true;
+
+    for (final entry in awardData.entries) {
+      if (entry.key != null) {
+        items.add(_SectionHeader(label: entry.key!, isTop: isFirst));
+        isFirst = false;
+      }
+      for (final year in yearsDesc) {
+        final works = entry.value[year];
+        if (works == null) continue;
+
+        if (entry.key != null) {
+          items.add(_SubSectionHeader(label: '${year.displayName}年度入学'));
+        } else {
+          items.add(
+              _SectionHeader(label: '${year.displayName}年度入学', isTop: isFirst));
+          isFirst = false;
+        }
+        for (final work in works) {
+          items.add(_WorkCard(work: work));
+        }
+      }
+    }
+
+    return ListView(children: items);
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String label;
+  final bool isTop;
+  const _SectionHeader({required this.label, required this.isTop});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding:
+          EdgeInsets.only(left: 16, right: 16, top: isTop ? 12 : 20, bottom: 8),
+      child: Text(
+        label,
+        style: Theme.of(context)
+            .textTheme
+            .titleMedium
+            ?.copyWith(fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+}
+
+class _SubSectionHeader extends StatelessWidget {
+  final String label;
+  const _SubSectionHeader({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.only(left: 24, right: 16, top: 12, bottom: 4),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+              fontWeight: FontWeight.w600,
+            ),
+      ),
+    );
+  }
+}
+
+class _WorkCard extends StatelessWidget {
+  final Searched work;
+  const _WorkCard({required this.work});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: ResultPreviewContent(
+        searched: work,
+        mode: ResultPreviewMode.search,
+        showAwardChip: false,
+      ),
+    );
+  }
+}

--- a/lib/features/krgp/presentation/screens/krgp_awards_page.dart
+++ b/lib/features/krgp/presentation/screens/krgp_awards_page.dart
@@ -14,10 +14,8 @@ class KrgpAwardsPage extends ConsumerStatefulWidget {
   ConsumerState<KrgpAwardsPage> createState() => _KrgpAwardsPageState();
 }
 
-class _KrgpAwardsPageState extends ConsumerState<KrgpAwardsPage>
-    with TickerProviderStateMixin {
+class _KrgpAwardsPageState extends ConsumerState<KrgpAwardsPage> {
   KrgpSortMode _sortMode = KrgpSortMode.year;
-  TabController? _tabController;
 
   // undefined を除いた年度リスト（新しい順）
   static final _years = EnterYear.values
@@ -27,27 +25,16 @@ class _KrgpAwardsPageState extends ConsumerState<KrgpAwardsPage>
       .toList();
 
   @override
-  void dispose() {
-    _tabController?.dispose();
-    super.dispose();
-  }
-
-  void _buildTabController(int length) {
-    _tabController?.dispose();
-    _tabController = TabController(length: length, vsync: this);
-  }
-
-  @override
   Widget build(BuildContext context) {
     final asyncWorks = ref.watch(krgpAwardsProvider);
 
     return asyncWorks.when(
       loading: () => Scaffold(
-        appBar: _buildAppBar(context, null),
+        appBar: _buildAppBar(context),
         body: const Center(child: CircularProgressIndicator()),
       ),
       error: (e, st) => Scaffold(
-        appBar: _buildAppBar(context, null),
+        appBar: _buildAppBar(context),
         body: CommonErrorView(
           error: e,
           onRetry: () => ref.invalidate(krgpAwardsProvider),
@@ -58,78 +45,78 @@ class _KrgpAwardsPageState extends ConsumerState<KrgpAwardsPage>
           final grouped = groupByYear(works);
           final availableYears =
               _years.where((y) => grouped.containsKey(y)).toList();
-          if (_tabController == null ||
-              _tabController!.length != availableYears.length) {
-            _buildTabController(availableYears.length);
+          if (availableYears.isEmpty) {
+            return Scaffold(
+              appBar: _buildAppBar(context),
+              body: const Center(child: Text('データがありません')),
+            );
           }
-          return Scaffold(
-            appBar: _buildAppBar(context, _tabController),
-            body: availableYears.isEmpty
-                ? const Center(child: Text('データがありません'))
-                : Column(
-                    children: [
-                      TabBar(
-                        controller: _tabController,
-                        isScrollable: true,
-                        tabAlignment: TabAlignment.start,
-                        tabs: availableYears
-                            .map((y) => Tab(text: '${y.displayName}年度入学'))
-                            .toList(),
-                      ),
-                      Expanded(
-                        child: TabBarView(
-                          controller: _tabController,
-                          children: availableYears
-                              .map((y) => _YearTabContent(
-                                    yearData: grouped[y]!,
-                                  ))
-                              .toList(),
-                        ),
-                      ),
-                    ],
+          return DefaultTabController(
+            key: ValueKey('year_${availableYears.length}'),
+            length: availableYears.length,
+            child: Scaffold(
+              appBar: _buildAppBar(context),
+              body: Column(
+                children: [
+                  TabBar(
+                    isScrollable: true,
+                    tabAlignment: TabAlignment.start,
+                    tabs: availableYears
+                        .map((y) => Tab(text: '${y.displayName}年度入学'))
+                        .toList(),
                   ),
+                  Expanded(
+                    child: TabBarView(
+                      children: availableYears
+                          .map((y) => _YearTabContent(yearData: grouped[y]!))
+                          .toList(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           );
         } else {
           final grouped = groupByAward(works);
           final availableTypes =
               AwardType.values.where((t) => grouped.containsKey(t)).toList();
-          if (_tabController == null ||
-              _tabController!.length != availableTypes.length) {
-            _buildTabController(availableTypes.length);
+          if (availableTypes.isEmpty) {
+            return Scaffold(
+              appBar: _buildAppBar(context),
+              body: const Center(child: Text('データがありません')),
+            );
           }
-          return Scaffold(
-            appBar: _buildAppBar(context, _tabController),
-            body: availableTypes.isEmpty
-                ? const Center(child: Text('データがありません'))
-                : Column(
-                    children: [
-                      TabBar(
-                        controller: _tabController,
-                        isScrollable: true,
-                        tabAlignment: TabAlignment.start,
-                        tabs: availableTypes
-                            .map((t) => Tab(text: t.displayName))
-                            .toList(),
-                      ),
-                      Expanded(
-                        child: TabBarView(
-                          controller: _tabController,
-                          children: availableTypes
-                              .map((t) => _AwardTabContent(
-                                    awardData: grouped[t]!,
-                                  ))
-                              .toList(),
-                        ),
-                      ),
-                    ],
+          return DefaultTabController(
+            key: ValueKey('award_${availableTypes.length}'),
+            length: availableTypes.length,
+            child: Scaffold(
+              appBar: _buildAppBar(context),
+              body: Column(
+                children: [
+                  TabBar(
+                    isScrollable: true,
+                    tabAlignment: TabAlignment.start,
+                    tabs: availableTypes
+                        .map((t) => Tab(text: t.displayName))
+                        .toList(),
                   ),
+                  Expanded(
+                    child: TabBarView(
+                      children: availableTypes
+                          .map((t) => _AwardTabContent(awardData: grouped[t]!))
+                          .toList(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           );
         }
       },
     );
   }
 
-  AppBar _buildAppBar(BuildContext context, TabController? tabController) {
+  AppBar _buildAppBar(BuildContext context) {
     return AppBar(
       title: const Text('KRGP受賞作品'),
       actions: [
@@ -139,10 +126,7 @@ class _KrgpAwardsPageState extends ConsumerState<KrgpAwardsPage>
           initialValue: _sortMode,
           onSelected: (mode) {
             if (mode == _sortMode) return;
-            setState(() {
-              _sortMode = mode;
-              _tabController = null;
-            });
+            setState(() => _sortMode = mode);
           },
           itemBuilder: (context) => [
             const PopupMenuItem(

--- a/lib/features/krgp/presentation/screens/krgp_awards_page.dart
+++ b/lib/features/krgp/presentation/screens/krgp_awards_page.dart
@@ -283,6 +283,7 @@ class _WorkCard extends StatelessWidget {
         searched: work,
         mode: ResultPreviewMode.search,
         showAwardChip: false,
+        showLikes: false,
       ),
     );
   }

--- a/lib/features/krgp/presentation/screens/krgp_awards_page.dart
+++ b/lib/features/krgp/presentation/screens/krgp_awards_page.dart
@@ -19,13 +19,12 @@ class _KrgpAwardsPageState extends ConsumerState<KrgpAwardsPage>
   KrgpSortMode _sortMode = KrgpSortMode.year;
   TabController? _tabController;
 
-  static const _years = [
-    EnterYear.enter2024,
-    EnterYear.enter2023,
-    EnterYear.enter2022,
-    EnterYear.enter2021,
-    EnterYear.enter2020,
-  ];
+  // undefined を除いた年度リスト（新しい順）
+  static final _years = EnterYear.values
+      .where((y) => y != EnterYear.undefined)
+      .toList()
+      .reversed
+      .toList();
 
   @override
   void dispose() {
@@ -193,16 +192,14 @@ class _AwardTabContent extends StatelessWidget {
   final Map<String?, Map<EnterYear, List<Searched>>> awardData;
   const _AwardTabContent({required this.awardData});
 
+  static final _yearsDesc = EnterYear.values
+      .where((y) => y != EnterYear.undefined)
+      .toList()
+      .reversed
+      .toList();
+
   @override
   Widget build(BuildContext context) {
-    const yearsDesc = [
-      EnterYear.enter2024,
-      EnterYear.enter2023,
-      EnterYear.enter2022,
-      EnterYear.enter2021,
-      EnterYear.enter2020,
-    ];
-
     final items = <Widget>[];
     var isFirst = true;
 
@@ -211,7 +208,7 @@ class _AwardTabContent extends StatelessWidget {
         items.add(_SectionHeader(label: entry.key!, isTop: isFirst));
         isFirst = false;
       }
-      for (final year in yearsDesc) {
+      for (final year in _yearsDesc) {
         final works = entry.value[year];
         if (works == null) continue;
 

--- a/lib/features/research_work/domain/models/searched.dart
+++ b/lib/features/research_work/domain/models/searched.dart
@@ -91,6 +91,8 @@ abstract class Searched with _$Searched {
     map.putIfAbsent('existsReport', () => false);
     map.putIfAbsent('existsThesis', () => false);
     map.putIfAbsent('existsPoster', () => false);
+    map.putIfAbsent('category2', () => 'none');
+    map.putIfAbsent('subCategory2', () => 'none');
     return Searched.fromJson(map).copyWith(
       documentID: documentID,
       isFavorite: false,

--- a/lib/features/research_work/domain/models/searched.dart
+++ b/lib/features/research_work/domain/models/searched.dart
@@ -82,6 +82,22 @@ abstract class Searched with _$Searched {
         documentID: int.parse(doc.id), isFavorite: isFavorite, isCached: false);
   }
 
+  /// krgp/awards の works 配列の各要素からパースする
+  factory Searched.fromKrgpDb(Map<String, dynamic> raw) {
+    final map = Map<String, dynamic>.from(raw);
+    final documentID = (map['documentID'] as num?)?.toInt() ?? 0;
+    map.putIfAbsent('likes', () => 0);
+    map.putIfAbsent('existsSlide', () => false);
+    map.putIfAbsent('existsReport', () => false);
+    map.putIfAbsent('existsThesis', () => false);
+    map.putIfAbsent('existsPoster', () => false);
+    return Searched.fromJson(map).copyWith(
+      documentID: documentID,
+      isFavorite: false,
+      isCached: false,
+    );
+  }
+
   factory Searched.fromSQLite(Map<String, dynamic> json) {
     final mutableJson = Map<String, dynamic>.from(json);
     //SQLiteから取得したデータは、0,1で保存されているため、bool型に変換する。

--- a/lib/features/search/presentation/widgets/result_preview_content.dart
+++ b/lib/features/search/presentation/widgets/result_preview_content.dart
@@ -13,8 +13,12 @@ enum ResultPreviewMode { search, library }
 class ResultPreviewContent extends ConsumerWidget {
   final Searched searched;
   final ResultPreviewMode mode;
+  final bool showAwardChip;
   const ResultPreviewContent(
-      {super.key, required this.searched, required this.mode});
+      {super.key,
+      required this.searched,
+      required this.mode,
+      this.showAwardChip = true});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -93,7 +97,8 @@ class ResultPreviewContent extends ConsumerWidget {
                         children: [
                           Text(
                               '${searched.enterYear.displayName.toString()}年度入学 ${searched.course.displayName}'),
-                          if (searched.awardDisplayText != null)
+                          if (showAwardChip &&
+                              searched.awardDisplayText != null)
                             AwardChip(text: searched.awardDisplayText!),
                         ],
                       ),

--- a/lib/features/search/presentation/widgets/result_preview_content.dart
+++ b/lib/features/search/presentation/widgets/result_preview_content.dart
@@ -14,11 +14,13 @@ class ResultPreviewContent extends ConsumerWidget {
   final Searched searched;
   final ResultPreviewMode mode;
   final bool showAwardChip;
+  final bool showLikes;
   const ResultPreviewContent(
       {super.key,
       required this.searched,
       required this.mode,
-      this.showAwardChip = true});
+      this.showAwardChip = true,
+      this.showLikes = true});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -112,6 +114,7 @@ class ResultPreviewContent extends ConsumerWidget {
                     searched: searched,
                     isLarge: false,
                     enabled: mode == ResultPreviewMode.library,
+                    showLikes: showLikes,
                   ),
                 ),
               ],

--- a/lib/features/user_archive/presentation/widgets/favorite_button.dart
+++ b/lib/features/user_archive/presentation/widgets/favorite_button.dart
@@ -13,6 +13,7 @@ class FavoriteButton extends ConsumerStatefulWidget {
   final bool isLarge;
   final bool enabled;
   final bool horizontal;
+  final bool showLikes;
 
   const FavoriteButton({
     super.key,
@@ -20,6 +21,7 @@ class FavoriteButton extends ConsumerStatefulWidget {
     this.isLarge = false,
     this.enabled = true,
     this.horizontal = false,
+    this.showLikes = true,
   });
 
   @override
@@ -76,7 +78,7 @@ class _FavoriteButtonState extends ConsumerState<FavoriteButton> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Icon(icon, color: color, size: widget.isLarge ? 24 : 20),
-          if (!widget.searched.isCached) ...[
+          if (widget.showLikes && !widget.searched.isCached) ...[
             const SizedBox(width: 4),
             Text(
               likes.toString(),
@@ -94,7 +96,7 @@ class _FavoriteButtonState extends ConsumerState<FavoriteButton> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Icon(icon, color: color, size: widget.isLarge ? 28 : 24),
-          if (!widget.searched.isCached) ...[
+          if (widget.showLikes && !widget.searched.isCached) ...[
             const SizedBox(height: 4),
             Text(
               likes.toString(),

--- a/lib/presentation/screens/home_page.dart
+++ b/lib/presentation/screens/home_page.dart
@@ -53,6 +53,8 @@ class _HomePageState extends ConsumerState<HomePage> {
             const SizedBox(height: 8),
             const UserStatsSection(),
             const SizedBox(height: 16),
+            _KrgpBannerCard(),
+            const SizedBox(height: 16),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
@@ -130,6 +132,52 @@ class _HomePageState extends ConsumerState<HomePage> {
             ),
             const SizedBox(height: 16),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _KrgpBannerCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => context.push('/krgp'),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'KRGP受賞作品',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '縣陵探究グランプリの受賞作品を年度・賞ごとに閲覧できます',
+                      style: Theme.of(context).textTheme.bodySmall,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.emoji_events,
+                size: 40,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              const Icon(Icons.chevron_right),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 概要
ホームページからアクセスできるKRGP受賞作品ページを新規追加。Firestoreの `krgp/awards` から作品データを取得し、年度別・賞別タブで閲覧できる。

## 種別
- [x] 機能追加

## 関連Issue
Closes #  

## 変更内容
- **ホームページ**: KRGPバナーカード追加（トロフィーアイコン＋説明文、タップで `/krgp` へ遷移）
- **ルーター**: `/krgp` ルート追加
- **KRGPデータソース** (`krgp/data/datasources/krgp_remote_data_source.dart`): Firestore `krgp/awards` ドキュメントの `works` 配列を取得
- **KRGPプロバイダー** (`krgp/presentation/providers/krgp_provider.dart`): `keepAlive: true` で1度だけ取得してキャッシュ。年度別・賞別グルーピング関数も定義
- **KRGPページ** (`krgp/presentation/screens/krgp_awards_page.dart`):
  - `DefaultTabController` でスクロール可能なタブ（年度別: 2024→2020 / 賞別: 大賞→優秀賞→奨励賞→入賞）
  - AppBarの並び替えボタンでモード切替（再フェッチなし）
  - 年度別モード: タブ内を賞種別でセクション分け、`awardName`（弱音を吐くな賞等）があればサブヘッダー表示
  - 賞別モード: タブ内を年度でセクション分け
  - 各作品は `ResultPreviewContent` で表示（賞チップは非表示）
- **`Searched.fromKrgpDb`**: krgp配列要素のパース処理をモデルに集約（`fromFirestore` 等と対比できる形）
- **`ResultPreviewContent`**: `showAwardChip` オプション追加（デフォルト `true`）
- **年度リスト**: ページ内の重複リストを廃止し `EnterYear.values` から生成に統一

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）