### PR TITLE
[Review #219] contextシャドウイング修正・groupBy最適化・型チェック強化

### DIFF
--- a/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
+++ b/lib/features/krgp/data/datasources/krgp_remote_data_source.dart
@@ -19,7 +19,8 @@ class KrgpRemoteDataSource {
     final docData = doc.data();
     if (docData == null) return [];
 
-    final rawWorks = docData['works'] as List<dynamic>? ?? [];
+    final worksData = docData['works'];
+    final rawWorks = worksData is List<dynamic> ? worksData : <dynamic>[];
     final results = <Searched>[];
 
     for (final item in rawWorks) {

--- a/lib/features/krgp/presentation/providers/krgp_provider.dart
+++ b/lib/features/krgp/presentation/providers/krgp_provider.dart
@@ -20,25 +20,21 @@ Map<EnterYear, Map<AwardType, Map<String?, List<Searched>>>> groupByYear(
     List<Searched> works) {
   final result = <EnterYear, Map<AwardType, Map<String?, List<Searched>>>>{};
 
-  for (final year in EnterYear.values.where((y) => y != EnterYear.undefined)) {
-    final byYear = works.where((w) => w.enterYear == year).toList();
-    if (byYear.isEmpty) continue;
+  for (final work in works) {
+    final year = work.enterYear;
+    if (year == EnterYear.undefined) continue;
 
-    final byType = <AwardType, Map<String?, List<Searched>>>{};
-    for (final type in AwardType.values) {
-      final byAwardType = byYear.where((w) => w.awardType == type).toList();
-      if (byAwardType.isEmpty) continue;
+    final type = work.awardType;
+    if (type == null) continue;
 
-      final byName = <String?, List<Searched>>{};
-      for (final work in byAwardType) {
-        final key = work.awardName?.trim().isEmpty ?? true
-            ? null
-            : work.awardName?.trim();
-        byName.putIfAbsent(key, () => []).add(work);
-      }
-      byType[type] = byName;
-    }
-    if (byType.isNotEmpty) result[year] = byType;
+    final nameKey =
+        work.awardName?.trim().isEmpty ?? true ? null : work.awardName?.trim();
+
+    result
+        .putIfAbsent(year, () => {})
+        .putIfAbsent(type, () => {})
+        .putIfAbsent(nameKey, () => [])
+        .add(work);
   }
 
   return result;
@@ -49,19 +45,18 @@ Map<AwardType, Map<String?, Map<EnterYear, List<Searched>>>> groupByAward(
     List<Searched> works) {
   final result = <AwardType, Map<String?, Map<EnterYear, List<Searched>>>>{};
 
-  for (final type in AwardType.values) {
-    final byType = works.where((w) => w.awardType == type).toList();
-    if (byType.isEmpty) continue;
+  for (final work in works) {
+    final type = work.awardType;
+    if (type == null) continue;
 
-    final byName = <String?, Map<EnterYear, List<Searched>>>{};
-    for (final work in byType) {
-      final nameKey = work.awardName?.trim().isEmpty ?? true
-          ? null
-          : work.awardName?.trim();
-      final byYear = byName.putIfAbsent(nameKey, () => {});
-      byYear.putIfAbsent(work.enterYear, () => []).add(work);
-    }
-    result[type] = byName;
+    final nameKey =
+        work.awardName?.trim().isEmpty ?? true ? null : work.awardName?.trim();
+
+    result
+        .putIfAbsent(type, () => {})
+        .putIfAbsent(nameKey, () => {})
+        .putIfAbsent(work.enterYear, () => [])
+        .add(work);
   }
 
   return result;

--- a/lib/features/research_work/presentation/widgets/header_for_result.dart
+++ b/lib/features/research_work/presentation/widgets/header_for_result.dart
@@ -41,7 +41,7 @@ class HeaderForResultPage extends ConsumerWidget
                   ),
                 ),
                 PopupMenuButton(
-                  itemBuilder: (context) {
+                  itemBuilder: (_) {
                     return [
                       PopupMenuItem(
                         onTap: () {


### PR DESCRIPTION
## 概要
PR [#219](https://github.com/minti05/kenryo_tankyu/pull/219) へのGeminiレビュー指摘4点を修正します。

## 種別
- [x] バグ修正
- [x] リファクタリング

## 関連Issue
Closes #  

## 変更内容

### [high] contextシャドウイングによるiPad共有シート再発バグを修正
`PopupMenuButton` の `itemBuilder` 引数名が `context` になっており、親WidgetのBuildContextをシャドウイングしていた。  
`PopupMenuItem.onTap` 実行時点ではメニューのcontextがアンマウント済みのため `shareSearched` に渡すと `context.mounted == false` になり、iPadで共有シートが表示されない問題が再発する。  
→ 引数名を `_` に変更し、親スコープの安定したcontextが渡るよう修正。

### [medium] `groupByYear` / `groupByAward` をシングルパスO(N)に最適化
`where` による複数回フィルタリングをやめ、1ループで `putIfAbsent` を使ってマップを構築するよう書き換え。表示順はUI側の `_years` / `AwardType.values` で制御されるため、動作に影響なし。

### [medium] `krgpRemoteDataSource` の型チェック強化
`docData['works'] as List<dynamic>? ?? []` の直接キャストを、`is List<dynamic>` による型チェック後のキャストに変更。Firestoreのデータ構造変更に対して堅牢に。

## スクリーンショット

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）