### PR TITLE
[Search] 検索結果のフィルターUXとヘッダー表示を改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ app.*.map.json
 
 # AI prompt
 /CLAUDE.md
+/AGENTS.md
 
 # Firebase CLI
 .firebase/

--- a/lib/core/constants/work/search_value.dart
+++ b/lib/core/constants/work/search_value.dart
@@ -3,7 +3,7 @@
 enum SortType { newOrder, oldOrder, likeOrder }
 
 extension SortTypeExtension on SortType {
-  String get name {
+  String get displayName {
     switch (this) {
       case SortType.newOrder:
         return '新しい順';

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -8,45 +8,20 @@ import 'package:kenryo_tankyu/features/search/presentation/widgets/result_header
 import 'package:kenryo_tankyu/features/search/presentation/widgets/sidebar.dart';
 
 import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 import 'package:kenryo_tankyu/core/connectivity/connectivity_provider.dart';
 
 class ResultListPage extends ConsumerWidget {
-  ResultListPage({super.key});
+  const ResultListPage({super.key});
 
-  ///drawerを開くボタンをbody内で使うために、ScaffoldにGlobalKeyを指定して、Scaffoldの状態を保持しているScaffoldStateを参照できるようにします。
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ///書き換えるときに使うところ
     return Scaffold(
-      key: _scaffoldKey,
-      appBar: const ResultHeader(),
+      appBar: ResultHeader(onOpenFilters: () => _openFilters(context, ref)),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8.0),
         child: Column(
           children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                PopupMenuButton(
-                  icon: const Icon(Icons.sort),
-                  itemBuilder: (context) {
-                    return SortType.values //sortTypeはvalue.dartに定義
-                        .map((e) => PopupMenuItem(
-                              onTap: () => ref
-                                  .read(sortedListProvider.notifier)
-                                  .sortList(e),
-                              value: e,
-                              child: Text(e.name),
-                            ))
-                        .toList();
-                  },
-                ),
-                IconButton(
-                    onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
-                    icon: const Icon(Icons.tune)),
-              ],
-            ),
             Expanded(
               child: Consumer(
                 builder: (context, ref, child) {
@@ -65,6 +40,18 @@ class ResultListPage extends ConsumerWidget {
                         return Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
+                            _SearchResultToolbar(
+                              resultCount: data.nbHits,
+                              rangeStart:
+                                  hits.isEmpty ? null : currentPage * 20 + 1,
+                              rangeEnd: hits.isEmpty
+                                  ? null
+                                  : currentPage * 20 + hits.length,
+                              onSort: (sortType) => ref
+                                  .read(sortedListProvider.notifier)
+                                  .sortList(sortType),
+                              onOpenFilters: () => _openFilters(context, ref),
+                            ),
                             if (hits.isEmpty)
                               const Expanded(
                                 child: Center(
@@ -72,17 +59,6 @@ class ResultListPage extends ConsumerWidget {
                                     'ヒットしませんでした。\nキーワードやカテゴリを変えて再検索してください。',
                                     textAlign: TextAlign.center,
                                   ),
-                                ),
-                              )
-                            else
-                              Padding(
-                                padding: const EdgeInsets.only(
-                                    left: 8.0, top: 4.0, bottom: 4.0),
-                                child: Text(
-                                  data.isLastPage && currentPage == 0
-                                      ? '${hits.length}件ヒットしました'
-                                      : '${currentPage * 20 + 1}〜${currentPage * 20 + hits.length}件目を表示中（総${data.nbHits}件）',
-                                  style: const TextStyle(fontSize: 16),
                                 ),
                               ),
                             if (hits.isNotEmpty) ResultList(data: sortedList),
@@ -177,7 +153,118 @@ class ResultListPage extends ConsumerWidget {
           ],
         ),
       ),
-      endDrawer: const SideBar(),
+    );
+  }
+
+  Future<void> _openFilters(BuildContext context, WidgetRef ref) async {
+    final selected = await showSearchFilterSheet(
+      context,
+      ref.read(searchProvider),
+    );
+    if (selected == null) return;
+    ref.read(searchProvider.notifier).setParameters(selected);
+    ref.invalidate(algoliaSearchProvider);
+  }
+}
+
+class _SearchResultToolbar extends StatelessWidget {
+  const _SearchResultToolbar({
+    required this.resultCount,
+    required this.rangeStart,
+    required this.rangeEnd,
+    required this.onSort,
+    required this.onOpenFilters,
+  });
+
+  final int resultCount;
+  final int? rangeStart;
+  final int? rangeEnd;
+  final ValueChanged<SortType> onSort;
+  final VoidCallback onOpenFilters;
+
+  @override
+  Widget build(BuildContext context) {
+    final actionStyle = TextButton.styleFrom(
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      minimumSize: const Size(0, 36),
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      visualDensity: VisualDensity.compact,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              rangeStart == null
+                  ? '0件（全$resultCount件）'
+                  : '$rangeStart〜$rangeEnd件（全$resultCount件）',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+          ),
+          PopupMenuButton<SortType>(
+            tooltip: '並び替え',
+            padding: EdgeInsets.zero,
+            onSelected: onSort,
+            itemBuilder: (context) => SortType.values
+                .map(
+                  (sortType) => PopupMenuItem(
+                    value: sortType,
+                    child: Text(sortType.name),
+                  ),
+                )
+                .toList(),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 6),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.swap_vert_rounded,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(width: 4),
+                  const Text('並び替え', style: TextStyle(fontSize: 13)),
+                ],
+              ),
+            ),
+          ),
+          _ToolbarAction(
+            icon: Icons.tune_rounded,
+            label: 'フィルター',
+            style: actionStyle,
+            onPressed: onOpenFilters,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToolbarAction extends StatelessWidget {
+  const _ToolbarAction({
+    required this.icon,
+    required this.label,
+    required this.style,
+    this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final ButtonStyle style;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon, size: 18),
+      label: Text(label, style: const TextStyle(fontSize: 13)),
+      style: style,
     );
   }
 }

--- a/lib/features/search/presentation/screens/result_list_page.dart
+++ b/lib/features/search/presentation/screens/result_list_page.dart
@@ -213,7 +213,7 @@ class _SearchResultToolbar extends StatelessWidget {
                 .map(
                   (sortType) => PopupMenuItem(
                     value: sortType,
-                    child: Text(sortType.name),
+                    child: Text(sortType.displayName),
                   ),
                 )
                 .toList(),

--- a/lib/features/search/presentation/widgets/result_header.dart
+++ b/lib/features/search/presentation/widgets/result_header.dart
@@ -23,7 +23,6 @@ class ResultHeader extends ConsumerStatefulWidget
 
 class _ResultHeaderState extends ConsumerState<ResultHeader> {
   late final TextEditingController _controller;
-  late final FocusNode _keywordFocusNode;
 
   @override
   void initState() {
@@ -31,26 +30,26 @@ class _ResultHeaderState extends ConsumerState<ResultHeader> {
     _controller = TextEditingController(
       text: ref.read(searchProvider).searchWord.join(' '),
     );
-    _keywordFocusNode = FocusNode();
   }
 
   @override
   void dispose() {
     _controller.dispose();
-    _keywordFocusNode.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<Search>(searchProvider, (previous, next) {
+      final keyword = next.searchWord.join(' ');
+      if (_controller.text != keyword) {
+        _controller.value = TextEditingValue(
+          text: keyword,
+          selection: TextSelection.collapsed(offset: keyword.length),
+        );
+      }
+    });
     final search = ref.watch(searchProvider);
-    final keyword = search.searchWord.join(' ');
-    if (_controller.text != keyword && !_keywordFocusNode.hasFocus) {
-      _controller.value = TextEditingValue(
-        text: keyword,
-        selection: TextSelection.collapsed(offset: keyword.length),
-      );
-    }
     final conditions = _conditionLabels(search);
 
     return AppBar(
@@ -58,7 +57,13 @@ class _ResultHeaderState extends ConsumerState<ResultHeader> {
       backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
       leadingWidth: 48,
       titleSpacing: 0,
-      leading: BackButton(onPressed: () => context.pop()),
+      leading: Align(
+        alignment: Alignment.topCenter,
+        child: Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: BackButton(onPressed: () => context.pop()),
+        ),
+      ),
       title: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8),
         child: Column(
@@ -68,7 +73,6 @@ class _ResultHeaderState extends ConsumerState<ResultHeader> {
               height: 36,
               child: TextField(
                 controller: _controller,
-                focusNode: _keywordFocusNode,
                 textInputAction: TextInputAction.search,
                 decoration: InputDecoration(
                   hintText: 'キーワードを入力',
@@ -102,7 +106,7 @@ class _ResultHeaderState extends ConsumerState<ResultHeader> {
                 color: Theme.of(context).colorScheme.surfaceContainer,
                 borderRadius: BorderRadius.circular(10),
                 child: InkWell(
-                  onTap: widget.onOpenFilters,
+                  onTap: _openFilters,
                   borderRadius: BorderRadius.circular(10),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 10),
@@ -166,13 +170,21 @@ class _ResultHeaderState extends ConsumerState<ResultHeader> {
   }
 
   void _applyKeyword(String text) {
-    final keywords = text
+    ref.read(searchProvider.notifier).addKeyWord(_parseKeywords(text));
+    ref.invalidate(algoliaSearchProvider);
+  }
+
+  void _openFilters() {
+    ref.read(searchProvider.notifier).addKeyWord(_parseKeywords(_controller.text));
+    widget.onOpenFilters();
+  }
+
+  List<String> _parseKeywords(String text) {
+    return text
         .replaceAll('　', ' ')
         .split(RegExp(r'\s+'))
         .where((word) => word.isNotEmpty)
         .toList();
-    ref.read(searchProvider.notifier).addKeyWord(keywords);
-    ref.invalidate(algoliaSearchProvider);
   }
 
   List<String> _conditionLabels(Search search) {

--- a/lib/features/search/presentation/widgets/result_header.dart
+++ b/lib/features/search/presentation/widgets/result_header.dart
@@ -175,7 +175,9 @@ class _ResultHeaderState extends ConsumerState<ResultHeader> {
   }
 
   void _openFilters() {
-    ref.read(searchProvider.notifier).addKeyWord(_parseKeywords(_controller.text));
+    ref
+        .read(searchProvider.notifier)
+        .addKeyWord(_parseKeywords(_controller.text));
     widget.onOpenFilters();
   }
 

--- a/lib/features/search/presentation/widgets/result_header.dart
+++ b/lib/features/search/presentation/widgets/result_header.dart
@@ -1,74 +1,193 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import "package:kenryo_tankyu/core/constants/work/sub_category_value.dart";
-import 'package:kenryo_tankyu/features/search/presentation/widgets/search_chip_list.dart';
-import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
-
+import 'package:kenryo_tankyu/core/constants/work/category_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
+import 'package:kenryo_tankyu/core/constants/work/sub_category_value.dart';
 import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
+import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
 
 class ResultHeader extends ConsumerStatefulWidget
     implements PreferredSizeWidget {
-  @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
-  const ResultHeader({super.key});
+  const ResultHeader({required this.onOpenFilters, super.key});
+
+  final Future<void> Function() onOpenFilters;
 
   @override
-  ResultHeaderState createState() => ResultHeaderState();
+  Size get preferredSize => const Size.fromHeight(104);
+
+  @override
+  ConsumerState<ResultHeader> createState() => _ResultHeaderState();
 }
 
-class ResultHeaderState extends ConsumerState<ResultHeader> {
+class _ResultHeaderState extends ConsumerState<ResultHeader> {
+  late final TextEditingController _controller;
+  late final FocusNode _keywordFocusNode;
+
   @override
   void initState() {
     super.initState();
-    ref.read(searchProvider);
+    _controller = TextEditingController(
+      text: ref.read(searchProvider).searchWord.join(' '),
+    );
+    _keywordFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _keywordFocusNode.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return AppBar(
-      actions: [Container()],
+    final search = ref.watch(searchProvider);
+    final keyword = search.searchWord.join(' ');
+    if (_controller.text != keyword && !_keywordFocusNode.hasFocus) {
+      _controller.value = TextEditingValue(
+        text: keyword,
+        selection: TextSelection.collapsed(offset: keyword.length),
+      );
+    }
+    final conditions = _conditionLabels(search);
 
-      ///drawerを開くボタンを消している
+    return AppBar(
+      toolbarHeight: widget.preferredSize.height,
       backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
+      leadingWidth: 48,
       titleSpacing: 0,
-      leading: BackButton(
-        onPressed: () => _backTo(context),
-      ),
+      leading: BackButton(onPressed: () => context.pop()),
       title: Padding(
-        padding: const EdgeInsets.only(right: 16.0),
-        child: SizedBox(
-          height: 40,
-          child: InkWell(
-            onTap: () => context.pop(),
-            child: Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(8.0),
-              ),
-              child: const Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  SizedBox(width: 16),
-                  Icon(Icons.search),
-                  SizedBox(width: 8),
-                  Expanded(child: SearchChipList(true)),
-                  SizedBox(width: 16),
-                ],
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              height: 36,
+              child: TextField(
+                controller: _controller,
+                focusNode: _keywordFocusNode,
+                textInputAction: TextInputAction.search,
+                decoration: InputDecoration(
+                  hintText: 'キーワードを入力',
+                  filled: true,
+                  fillColor:
+                      Theme.of(context).colorScheme.surfaceContainerHighest,
+                  prefixIcon: const Icon(Icons.search),
+                  prefixIconConstraints:
+                      const BoxConstraints.tightFor(width: 40, height: 36),
+                  suffixIcon: IconButton(
+                    onPressed: () => _controller.clear(),
+                    icon: const Icon(Icons.clear),
+                    tooltip: '入力を消去',
+                  ),
+                  suffixIconConstraints:
+                      const BoxConstraints.tightFor(width: 40, height: 36),
+                  contentPadding: EdgeInsets.zero,
+                  border: OutlineInputBorder(
+                    borderSide: BorderSide.none,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                onSubmitted: _applyKeyword,
               ),
             ),
-          ),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              height: 36,
+              child: Material(
+                color: Theme.of(context).colorScheme.surfaceContainer,
+                borderRadius: BorderRadius.circular(10),
+                child: InkWell(
+                  onTap: widget.onOpenFilters,
+                  borderRadius: BorderRadius.circular(10),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.tune_rounded,
+                          size: 17,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: conditions.isEmpty
+                              ? Text(
+                                  'フィルターを追加',
+                                  style: TextStyle(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurfaceVariant,
+                                    fontSize: 13,
+                                  ),
+                                )
+                              : SingleChildScrollView(
+                                  scrollDirection: Axis.horizontal,
+                                  child: Row(
+                                    children: conditions
+                                        .map(
+                                          (condition) => Padding(
+                                            padding: const EdgeInsets.only(
+                                                right: 16),
+                                            child: Text(
+                                              condition,
+                                              style: TextStyle(
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .onSurface,
+                                                fontSize: 13,
+                                              ),
+                                            ),
+                                          ),
+                                        )
+                                        .toList(),
+                                  ),
+                                ),
+                        ),
+                        Icon(
+                          Icons.chevron_right_rounded,
+                          size: 18,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
   }
 
-  void _backTo(BuildContext context) {
-    final notifier = ref.read(searchProvider.notifier);
-    final Search searchStatus = ref.read(searchProvider);
-    if (searchStatus.subCategory != SubCategory.none) {
-      notifier.deleteParameter('subCategory');
+  void _applyKeyword(String text) {
+    final keywords = text
+        .replaceAll('　', ' ')
+        .split(RegExp(r'\s+'))
+        .where((word) => word.isNotEmpty)
+        .toList();
+    ref.read(searchProvider.notifier).addKeyWord(keywords);
+    ref.invalidate(algoliaSearchProvider);
+  }
+
+  List<String> _conditionLabels(Search search) {
+    final labels = <String>[];
+    if (search.subCategory != SubCategory.none) {
+      labels.add('カテゴリ: ${search.subCategory.displayName}');
+    } else if (search.category != Category.none) {
+      labels.add('カテゴリ: ${search.category.displayName}');
     }
-    context.pop();
+    if (search.enterYear != EnterYear.undefined) {
+      labels.add('入学年度: ${search.enterYear.label}');
+    }
+    if (search.course != Course.undefined) {
+      labels.add('学科: ${search.course.displayName}');
+    }
+    return labels;
   }
 }

--- a/lib/features/search/presentation/widgets/sidebar.dart
+++ b/lib/features/search/presentation/widgets/sidebar.dart
@@ -2,88 +2,213 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kenryo_tankyu/core/constants/work/category_value.dart';
 import 'package:kenryo_tankyu/core/constants/work/info_value.dart';
-import 'package:kenryo_tankyu/features/search/presentation/providers/algolia_provider.dart';
-import 'package:kenryo_tankyu/features/search/presentation/providers/search_provider.dart';
-import 'package:kenryo_tankyu/features/search/presentation/widgets/drop_button.dart';
-import 'package:kenryo_tankyu/features/search/presentation/widgets/sub_category_chip.dart';
+import 'package:kenryo_tankyu/core/constants/work/sub_category_value.dart';
+import 'package:kenryo_tankyu/features/search/domain/models/search.dart';
 
-class SideBar extends ConsumerWidget {
-  const SideBar({super.key});
+/// Opens the filter as an editable draft. The caller applies the returned
+/// conditions only after the user explicitly taps the search button.
+Future<Search?> showSearchFilterSheet(BuildContext context, Search initial) {
+  return showModalBottomSheet<Search>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (_) => FractionallySizedBox(
+      heightFactor: 0.82,
+      child: SearchFilterSheet(initial: initial),
+    ),
+  );
+}
+
+class SearchFilterSheet extends ConsumerStatefulWidget {
+  const SearchFilterSheet({required this.initial, super.key});
+
+  final Search initial;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Align(
-      alignment: Alignment.topRight,
-      child: Drawer(
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.only(
-                left: 8.0, right: 16.0, top: 8.0, bottom: 16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+  ConsumerState<SearchFilterSheet> createState() => _SearchFilterSheetState();
+}
+
+class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
+  late final TextEditingController _keywordController;
+  late Search _draft;
+
+  @override
+  void initState() {
+    super.initState();
+    _draft = widget.initial;
+    _keywordController =
+        TextEditingController(text: _draft.searchWord.join(' '));
+  }
+
+  @override
+  void dispose() {
+    _keywordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+    return Material(
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 8, 4),
+            child: Row(
               children: [
-                Row(
-                  children: [
-                    IconButton(
-                        onPressed: () => Navigator.of(context).pop(),
-                        icon: const Icon(Icons.clear)),
-                    const Expanded(child: Text('絞り込み')),
-                    ElevatedButton(
-                        onPressed: () => ref
-                            .read(searchProvider.notifier)
-                            .deleteAllParameters(),
-                        child: const Text('条件をクリア')),
-                  ],
+                const Expanded(
+                  child: Text('絞り込み', style: TextStyle(fontSize: 20)),
                 ),
-                Consumer(builder: (context, ref, child) {
-                  final data = ref.watch(searchProvider);
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const SizedBox(height: 10.0),
-                      SearchDropButton(
-                          name: '年度指定',
-                          selectedText: data.enterYear.label,
-                          choices:
-                              EnterYear.values.map((e) => e.label).toList()),
-                      const SizedBox(height: 15.0),
-                      SearchDropButton(
-                          name: '学科指定',
-                          selectedText: data.course.displayName,
-                          choices:
-                              Course.values.map((e) => e.displayName).toList()),
-                      const SizedBox(height: 15.0),
-                      SearchDropButton(
-                          name: 'カテゴリ',
-                          selectedText: data.category.displayName,
-                          choices: Category.values
-                              .map((e) => e.displayName)
-                              .toList()),
-                      const SizedBox(height: 15.0),
-                      const Text('サブカテゴリを選択'),
-                      data.category != Category.none
-                          ? const SubCategoryChip()
-                          : const Text(
-                              'カテゴリを選択してください',
-                              style: TextStyle(fontSize: 20),
-                            ),
-                    ],
-                  );
-                }),
-                const Spacer(),
-                Center(
-                  child: ElevatedButton(
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        ref.invalidate(algoliaSearchProvider);
-                      },
-                      child: const Text('再検索する')),
+                TextButton(
+                  onPressed: _clear,
+                  child: const Text('条件をクリア'),
+                ),
+                IconButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(Icons.close),
+                  tooltip: '閉じる',
                 ),
               ],
             ),
           ),
-        ),
+          const Divider(height: 1),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(16, 20, 16, bottomInset + 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextField(
+                    controller: _keywordController,
+                    textInputAction: TextInputAction.done,
+                    decoration: const InputDecoration(
+                      labelText: 'キーワード検索',
+                      border: OutlineInputBorder(),
+                      prefixIcon: Icon(Icons.search),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  _sectionTitle('カテゴリ'),
+                  DropdownButtonFormField<Category>(
+                    value: _draft.category,
+                    decoration:
+                        const InputDecoration(border: OutlineInputBorder()),
+                    items: Category.values
+                        .map((category) => DropdownMenuItem(
+                              value: category,
+                              child: Text(category.displayName),
+                            ))
+                        .toList(),
+                    onChanged: (category) {
+                      if (category == null) return;
+                      setState(() {
+                        _draft = _draft.copyWith(
+                          category: category,
+                          subCategory: SubCategory.none,
+                        );
+                      });
+                    },
+                  ),
+                  if (_draft.category != Category.none) ...[
+                    const SizedBox(height: 24),
+                    _sectionTitle('サブカテゴリ'),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children:
+                          _draft.category.subCategories.map((subCategory) {
+                        return ChoiceChip(
+                          label: Text(subCategory.displayName),
+                          selected: _draft.subCategory == subCategory,
+                          onSelected: (selected) => setState(() {
+                            _draft = _draft.copyWith(
+                              subCategory:
+                                  selected ? subCategory : SubCategory.none,
+                            );
+                          }),
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                  const SizedBox(height: 24),
+                  _sectionTitle('入学年度'),
+                  DropdownButtonFormField<EnterYear>(
+                    value: _draft.enterYear,
+                    decoration:
+                        const InputDecoration(border: OutlineInputBorder()),
+                    items: EnterYear.values
+                        .map((year) => DropdownMenuItem(
+                              value: year,
+                              child: Text(year.label),
+                            ))
+                        .toList(),
+                    onChanged: (year) {
+                      if (year != null)
+                        setState(
+                            () => _draft = _draft.copyWith(enterYear: year));
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  _sectionTitle('学科'),
+                  DropdownButtonFormField<Course>(
+                    value: _draft.course,
+                    decoration:
+                        const InputDecoration(border: OutlineInputBorder()),
+                    items: Course.values
+                        .map((course) => DropdownMenuItem(
+                              value: course,
+                              child: Text(course.displayName),
+                            ))
+                        .toList(),
+                    onChanged: (course) {
+                      if (course != null)
+                        setState(
+                            () => _draft = _draft.copyWith(course: course));
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: _apply,
+                      icon: const Icon(Icons.search),
+                      label: const Text('再検索する'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
+  }
+
+  Widget _sectionTitle(String text) => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Text(text, style: const TextStyle(fontWeight: FontWeight.bold)),
+      );
+
+  void _clear() {
+    setState(() {
+      _draft = _draft.copyWith(
+        category: Category.none,
+        subCategory: SubCategory.none,
+        enterYear: EnterYear.undefined,
+        course: Course.undefined,
+        eventName: EventName.undefined,
+        searchWord: [],
+      );
+      _keywordController.clear();
+    });
+  }
+
+  void _apply() {
+    final keywords = _keywordController.text
+        .replaceAll('　', ' ')
+        .split(RegExp(r'\s+'))
+        .where((word) => word.isNotEmpty)
+        .toList();
+    Navigator.of(context).pop(_draft.copyWith(searchWord: keywords));
   }
 }

--- a/lib/features/search/presentation/widgets/sidebar.dart
+++ b/lib/features/search/presentation/widgets/sidebar.dart
@@ -90,7 +90,7 @@ class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
                   const SizedBox(height: 24),
                   _sectionTitle('カテゴリ'),
                   DropdownButtonFormField<Category>(
-                    value: _draft.category,
+                    initialValue: _draft.category,
                     decoration:
                         const InputDecoration(border: OutlineInputBorder()),
                     items: Category.values
@@ -133,7 +133,7 @@ class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
                   const SizedBox(height: 24),
                   _sectionTitle('入学年度'),
                   DropdownButtonFormField<EnterYear>(
-                    value: _draft.enterYear,
+                    initialValue: _draft.enterYear,
                     decoration:
                         const InputDecoration(border: OutlineInputBorder()),
                     items: EnterYear.values
@@ -152,7 +152,7 @@ class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
                   const SizedBox(height: 24),
                   _sectionTitle('学科'),
                   DropdownButtonFormField<Course>(
-                    value: _draft.course,
+                    initialValue: _draft.course,
                     decoration:
                         const InputDecoration(border: OutlineInputBorder()),
                     items: Course.values

--- a/lib/features/search/presentation/widgets/sidebar.dart
+++ b/lib/features/search/presentation/widgets/sidebar.dart
@@ -143,9 +143,10 @@ class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
                             ))
                         .toList(),
                     onChanged: (year) {
-                      if (year != null)
+                      if (year != null) {
                         setState(
                             () => _draft = _draft.copyWith(enterYear: year));
+                      }
                     },
                   ),
                   const SizedBox(height: 24),
@@ -161,9 +162,10 @@ class _SearchFilterSheetState extends ConsumerState<SearchFilterSheet> {
                             ))
                         .toList(),
                     onChanged: (course) {
-                      if (course != null)
+                      if (course != null) {
                         setState(
                             () => _draft = _draft.copyWith(course: course));
+                      }
                     },
                   ),
                   const SizedBox(height: 24),


### PR DESCRIPTION
## 概要
検索結果画面のフィルター操作とヘッダー表示を整理し、検索条件の確認・変更をより直感的に行えるようにします。

## 種別
- [ ] 機能追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明）

## 関連Issue
Closes #223

## 変更内容
- フィルターを確定操作まで検索へ反映しないハーフシートへ変更
- キーワードとフィルター条件を双方向に同期
- 検索ヘッダーで適用中の条件を横スクロール表示
- 検索結果の件数・並び替え・フィルターを1行に集約
- 検索結果の表示範囲と総件数を表示

## スクリーンショット
未添付

## セルフチェック
- [x] コードは正常に動作する
- [x] 不要なログやコメントを削除した
- [x] Lint / Format に問題なし
- [ ] テストを追加または更新済み（必要な場合）